### PR TITLE
fix(themes): 🐞 Reduce Tax Image Size

### DIFF
--- a/src/views/components/footer/footer.twig
+++ b/src/views/components/footer/footer.twig
@@ -20,7 +20,7 @@
             <div class="flex rtl:space-x-reverse space-x-2 items-end">
               {% if store.settings.tax.certificate %}
                 <a class="load-img-onclick" data-modal-id="modal-value-tax" href="#/" alt="{{ store.settings.tax.number }}">
-                  <img width="100%" height="100%" src="{{ 'images/s-empty.png' | cdn }}" data-src="{{'images/tax.png' | cdn}}" class="lazy w-10 rounded-sm hover:opacity-80 transition-opacity" alt="value added tax">
+                  <img width="100%" height="100%" src="{{ 'images/s-empty.png' | cdn }}" data-src="{{'images/tax.png' | cdn(70,70)}}" class="lazy w-10 rounded-sm hover:opacity-80 transition-opacity" alt="value added tax">
                 </a>
               {% endif %}
               <div>


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Enhancement

What is the current behaviour? (You can also link to an open issue here)

* Tax image appears on Google page speed report

What is the new behaviour? (You can also link to the ticket here)

* reduce the tax image size

Does this PR introduce a breaking change?

* no

Screenshots (If appropriate)

* 