### PR TITLE
fix(themes): show "display-all-button" in testimonials section only if option is activated

### DIFF
--- a/src/views/components/home/testimonials.twig
+++ b/src/views/components/home/testimonials.twig
@@ -13,7 +13,7 @@
 | type               | string                    | `default:store` all, product, store |
 | position           | string                    | Sorting number start from zero      |
 #}
-
+{% set display_all_url = theme.settings.get('is_more_button_enabled')%}
 <section class="s-block s-block--testimonials container overflow-hidden">
-    <salla-reviews display-all-link="{{ display_all_url }}"></salla-reviews>
+    <salla-reviews {{ display_all_url ? "display-all-link" : ''  }}></salla-reviews>
 </section> 

--- a/src/views/components/home/testimonials.twig
+++ b/src/views/components/home/testimonials.twig
@@ -13,7 +13,6 @@
 | type               | string                    | `default:store` all, product, store |
 | position           | string                    | Sorting number start from zero      |
 #}
-{% set display_all_url = theme.settings.get('is_more_button_enabled')%}
 <section class="s-block s-block--testimonials container overflow-hidden">
-    <salla-reviews {{ display_all_url ? "display-all-link" : ''  }}></salla-reviews>
+    <salla-reviews {{ theme.settings.get('is_more_button_enabled') ? "display-all-link" : ''  }}></salla-reviews>
 </section> 

--- a/src/views/components/home/testimonials.twig
+++ b/src/views/components/home/testimonials.twig
@@ -14,5 +14,5 @@
 | position           | string                    | Sorting number start from zero      |
 #}
 <section class="s-block s-block--testimonials container overflow-hidden">
-    <salla-reviews {{ theme.settings.get('is_more_button_enabled') ? "display-all-link" : ''  }}></salla-reviews>
+    <salla-reviews {{ display_all_url ?"display-all-link":"" }}></salla-reviews>
 </section> 


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* bug fix 

What is the current behavior ?  (You can also link to an open issue here)

*  The `show all` button is always visible on the testimonials

What is the new behaviour? (You can also link to the ticket here)

* the "display-all-button" is displayed only if option is activated

Does this PR introduce a breaking change?

* no 

Screenshots (If appropriate)

* 