### PR TITLE
fix(themes): TD-174 avoid setting cache on miss

### DIFF
--- a/src/assets/js/partials/main-menu.js
+++ b/src/assets/js/partials/main-menu.js
@@ -32,7 +32,7 @@ class NavigationMenu extends HTMLElement {
 
             salla.api.component.getMenus('header').then(({ data }) => {
                 this.menus = data;
-                salla.storage.setWithTTL(menusKey, this.menus)
+                !shouldSkipCaching && salla.storage.setWithTTL(menusKey, this.menus)
                 this.render();
 
             }).catch((error) => {


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Bugfix

What is the current behaviour? (You can also link to an open issue here)

* API cache is set on dev and design environment on first miss

What is the new behaviour? (You can also link to the ticket here)

* 

Does this PR introduce a breaking change?

* 

Screenshots (If appropriate)

* 