### PR TITLE
fix: Eager Loading Custom Components JS Files

### DIFF
--- a/src/views/layouts/master.twig
+++ b/src/views/layouts/master.twig
@@ -110,7 +110,7 @@
       });
     </script>
   
-    <script defer src="{{ 'product-card.js'|asset }}"></script>
+    <script data-cfasync="false" defer src="{{ 'product-card.js'|asset }}"></script>
     <script defer src="{{ 'main-menu.js'|asset }}"></script>
 
     {% block head_scripts %}{% endblock %}

--- a/src/views/layouts/master.twig
+++ b/src/views/layouts/master.twig
@@ -110,7 +110,7 @@
       });
     </script>
   
-    <script data-cfasync="false" defer src="{{ 'product-card.js'|asset }}"></script>
+    <script data-cfasync="false" src="{{ 'product-card.js'|asset }}"></script>
     <script defer src="{{ 'main-menu.js'|asset }}"></script>
 
     {% block head_scripts %}{% endblock %}

--- a/src/views/layouts/master.twig
+++ b/src/views/layouts/master.twig
@@ -110,7 +110,7 @@
       });
     </script>
   
-    <script data-cfasync="false" src="{{ 'product-card.js'|asset }}"></script>
+    <script defer data-cfasync="false" src="{{ 'product-card.js'|asset }}"></script>
     <script defer src="{{ 'main-menu.js'|asset }}"></script>
 
     {% block head_scripts %}{% endblock %}

--- a/src/views/pages/customer/wishlist.twig
+++ b/src/views/pages/customer/wishlist.twig
@@ -7,7 +7,7 @@
 #}
 {% extends "layouts.customer" %}
 {% block head_scripts %}
-	<script data-cfasync="false" src="{{ 'wishlist-card.js'|asset }}"></script>
+	<script defer data-cfasync="false" src="{{ 'wishlist-card.js'|asset }}"></script>
 {% endblock %}
 
 {% block inner_content %}

--- a/src/views/pages/customer/wishlist.twig
+++ b/src/views/pages/customer/wishlist.twig
@@ -7,7 +7,7 @@
 #}
 {% extends "layouts.customer" %}
 {% block head_scripts %}
-	<script data-cfasync="false" defer src="{{ 'wishlist-card.js'|asset }}"></script>
+	<script data-cfasync="false" src="{{ 'wishlist-card.js'|asset }}"></script>
 {% endblock %}
 
 {% block inner_content %}

--- a/src/views/pages/customer/wishlist.twig
+++ b/src/views/pages/customer/wishlist.twig
@@ -7,7 +7,7 @@
 #}
 {% extends "layouts.customer" %}
 {% block head_scripts %}
-	<script defer src="{{ 'wishlist-card.js'|asset }}"></script>
+	<script data-cfasync="false" defer src="{{ 'wishlist-card.js'|asset }}"></script>
 {% endblock %}
 
 {% block inner_content %}


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Bugfix

What is the current behaviour? (You can also link to an open issue here)

* Some times Twilight is loaded before Customer wishlist card js, so it didn't renders the wanted card

What is the new behaviour? (You can also link to the ticket here)

* Make sure to eager loading the js file, avoiding CloudFlare rocketLoader reOrder

Does this PR introduce a breaking change?

* No

Screenshots (If appropriate)

* 