### PR TITLE
feat(themes): TWILIGHT-1146 handle protected digital files 

### DIFF
--- a/src/assets/styles/04-components/user-pages.scss
+++ b/src/assets/styles/04-components/user-pages.scss
@@ -4,6 +4,12 @@
   }
 }
 
+.order-file {
+  .s-button-text {
+    @apply flex gap-2
+  }
+}
+
 /* tags */
 .tag {
   @apply px-3 pt-0.5 pb-1 inline-block text-sm rounded-2xl border border-gray-200;

--- a/src/views/pages/customer/orders/single.twig
+++ b/src/views/pages/customer/orders/single.twig
@@ -334,14 +334,15 @@
                                 <div class="flow-root rounded-md px-4 border border-gray-200">
                                     <dl class="text-sm text-dark divide-y divide-border-color">
                                         {% for file in item.files %}
-                                            <div class="py-2.5 center-between">
+                                            {% set is_protected = "download" in file.url ? false : true %}
+                                            <div class="order-file py-2.5 center-between">
                                                 <dt class="mb-2 md:mb-0">
                                                     {{ file.name }}
                                                 </dt>
                                                 <dd class="font-medium text-xs">
                                                     <salla-button href="{{ file.url }}" target="_blank"
                                                        class="btn--rounded-full font-bold text-gray-600 hover:text-black">
-                                                        <i class="sicon-download"></i> {{ trans('pages.thank_you.download') }}
+                                                        <i class="sicon-{{is_protected ? 'eye' : 'download'}}"></i> {{ is_protected ? trans('common.uploader.browse') : trans('pages.thank_you.download') }}
                                                     </salla-button>
                                                 </dd>
                                             </div>

--- a/src/views/pages/customer/orders/single.twig
+++ b/src/views/pages/customer/orders/single.twig
@@ -334,7 +334,7 @@
                                 <div class="flow-root rounded-md px-4 border border-gray-200">
                                     <dl class="text-sm text-dark divide-y divide-border-color">
                                         {% for file in item.files %}
-                                            {% set is_protected = "download" in file.url ? false : true %}
+                                            {% set is_protected = "/download" in file.url ? false : true %}
                                             <div class="order-file py-2.5 center-between">
                                                 <dt class="mb-2 md:mb-0">
                                                     {{ file.name }}


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Feature

What is the current behaviour? (You can also link to an open issue here)

* Browse protected digital files label and icon not supported

What is the new behaviour? (You can also link to the ticket here)

* Browse protected digital files label and icon are supported

Does this PR introduce a breaking change?

* No

Screenshots (If appropriate)

* 
![Screenshot 2024-07-15 at 10 07 09 PM](https://github.com/user-attachments/assets/972e5fb3-6aba-418c-8bb1-96efb0c6d6ad)
