### PR TITLE
fix(themes): display rating based on dashboard option

### DIFF
--- a/src/views/pages/product/single.twig
+++ b/src/views/pages/product/single.twig
@@ -205,7 +205,7 @@
                     </h2>
                 {% endif %}
 
-                {% if product.rating %}
+                {% if product.rating and store.settings.rating.show_rating_summary %}
                     <salla-rating-stars value="{{ product.rating.stars }}"
                                         reviews="{{ product.rating.count }}"></salla-rating-stars>
                 {% endif %}


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* bug fix

What is the current behaviour? (You can also link to an open issue here)

* display rating only if ( product.rating ) 

What is the new behaviour? (You can also link to the ticket here)

* display rating if (product.rating and store.settings.rating.show-rating-summary  )

Does this PR introduce a breaking change?

* no

Screenshots (If appropriate)

* 