### PR TITLE
fix(themes): TWILIGHT-2508 tracking link should open in new tab

### DIFF
--- a/src/views/pages/customer/orders/single.twig
+++ b/src/views/pages/customer/orders/single.twig
@@ -77,7 +77,7 @@
         <div class="flex space-x-2 rtl:space-x-reverse">
             {% for shipment in order.shipments %}
                 {% if shipment.tracking_url %}
-                <a href="{{shipment.tracking_url}}" class="text-primary">{{ trans('pages.orders.tracking') }} <i class="{{user.language.dir == 'rtl' ? 'sicon-arrow-up-left' : 'sicon-arrow-up-right' }}"></i></a>
+                <a href="{{shipment.tracking_url}}" class="text-primary" target="_blank">{{ trans('pages.orders.tracking') }} <i class="{{user.language.dir == 'rtl' ? 'sicon-arrow-up-left' : 'sicon-arrow-up-right' }}"></i></a>
                 {% endif %}
             {% endfor %}
         </div>


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Bugfix

What is the current behaviour? (You can also link to an open issue here)

* Shipment tracking link does not open in new tab

What is the new behaviour? (You can also link to the ticket here)

* 

Does this PR introduce a breaking change?

* 

Screenshots (If appropriate)

* 