### PR TITLE
fix(themes): fix max-quantity attribute in cart page

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.16.0",
     "@babel/plugin-transform-runtime": "^7.18.6",
     "@babel/preset-env": "^7.16.5",
-    "@salla.sa/twilight-components": "^2.14.4",
+    "@salla.sa/twilight-components": "^2.14.21",
     "@tailwindcss/forms": "^0.5.2",
     "@tailwindcss/line-clamp": "^0.4.0",
     "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",

--- a/src/views/pages/cart.twig
+++ b/src/views/pages/cart.twig
@@ -102,7 +102,7 @@
                                             <input type="hidden" value="{{ item.quantity }}" name="quantity" aria-label="Quantity"/>
                                             <span class="w-10 text-center">{{ item.quantity }}</span>
                                         {% else %}
-                                            <salla-quantity-input cart-item-id="{{ item.id }}"  max="{{ product.max_quantity }}"
+                                            <salla-quantity-input cart-item-id="{{ item.id }}"  max="{{ item.max_quantity }}"
                                                 class="transtion transition-color duration-300"
 												aria-label="Quantity"
                                                 value="{{ item.quantity }}" name="quantity">


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* bug fix

What is the current behaviour? (You can also link to an open issue here)

* Incorrect Quantity Adjustment When Reaching Maximum Product Quantity in Cart

What is the new behaviour? (You can also link to the ticket here)

* fix the issue

Does this PR introduce a breaking change?

* no

Screenshots (If appropriate)

* 