### PR TITLE
fix(TD-3364): resolve accessibility issues and achieve 100% score in Lighthouse audit

### DIFF
--- a/src/views/layouts/master.twig
+++ b/src/views/layouts/master.twig
@@ -55,7 +55,7 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ theme.settings.set('placeholder', 'images/placeholder.png') }}
 
     {% include 'pages.partials.loading-screen-assets' %}


### PR DESCRIPTION
### **What kind of change does this PR introduce?**  
*SEO Enhancement*

---

### **What is the current behavior?**  
Currently, the viewport meta tag includes `user-scalable="no"`, which prevents users from zooming on the page.  
This behavior negatively impacts accessibility, especially for visually impaired users who rely on browser zoom functionality.

---

### **What is the new behavior?**  
The `user-scalable="no"` attribute has been **removed** from the viewport meta tag.  
This change restores user zoom functionality and aligns with accessibility best practices.

**Updated meta tag:**
```html
<meta name="viewport" content="width=device-width, initial-scale=1.0">
```

---

### **Does this PR introduce a breaking change?**  
*No.*

---

### **Screenshots (If appropriate)**  

#### Before:
- Zoom functionality is disabled.  
- The Lighthouse accessibility score flags this as a **"Best Practices"** issue.
![image](https://github.com/user-attachments/assets/84e38f3d-5f3e-4ffa-a4e0-e32b7f6757e2)

---

#### After:
- Zoom functionality is restored.  
- The issue is resolved, and the Lighthouse accessibility score improves.
![image](https://github.com/user-attachments/assets/46465ca4-b248-44a7-8cfa-76d56733310f)

