### PR TITLE
feat(themes): ✨ Drop The Usage Of `order.items[].codes` & `files`

### DIFF
--- a/src/views/pages/customer/orders/single.twig
+++ b/src/views/pages/customer/orders/single.twig
@@ -346,45 +346,6 @@
                                     </dl>
                                 </div>
                             {% endif %}
-{% if item.files %}
-                                <h2 class="mb-3.5 text-sm font-bold">{{ trans('pages.orders.files') }}</h2>
-                                <div class="flow-root rounded-md px-4 border border-gray-200">
-                                    <dl class="text-sm text-dark divide-y divide-border-color">
-                                        {% for file in item.files %}
-                                            {% set is_protected = "/download" in file.url ? false : true %}
-                                            <div class="order-file py-2.5 center-between">
-                                                <dt class="mb-2 md:mb-0">
-                                                    {{ file.name }}
-                                                </dt>
-                                                <dd class="font-medium text-xs">
-                                                    <salla-button href="{{ file.url }}" target="_blank"
-                                                       class="btn--rounded-full font-bold text-gray-600 hover:text-black">
-                                                        <i class="sicon-{{is_protected ? 'eye' : 'download'}}"></i> {{ is_protected ? trans('common.uploader.browse') : trans('pages.thank_you.download') }}
-                                                    </salla-button>
-                                                </dd>
-                                            </div>
-                                        {% endfor %}
-                                    </dl>
-                                </div>
-                            {% elseif item.codes %}
-                                <h2 class="mb-3.5 text-sm font-bold">{{ trans('pages.orders.codes') }}</h2>
-                                <div class="flow-root rounded-md px-4 border border-gray-200">
-                                    <dl class="text-sm text-dark divide-y divide-border-color">
-                                        {% for code in item.codes %}
-                                            <div class="py-2.5 center-between">
-                                                <dt class="flex-center">
-                                                    <i class="sicon-debit-card-back text-xl rtl:ml-2 ltr:mr-2 text-gray-500 inline-block -mt-1"></i>
-                                                    <span class="break-all font-bold">{{ code.code }}</span>
-                                                </dt>
-                                                <salla-button class="btn--rounded-full" onclick="app.copyToClipboard(event)" data-content="{{ code.code }}">
-                                                    <i class="copy-icon sicon-swap-stroke pointer-events-none"></i>
-                                                    <span class="text-sm rtl:mr-2 ltr:ml-2 pointer-events-non">{{ trans('common.elements.copy') }}</span>
-                                                </salla-button>
-                                            </div>
-                                        {% endfor %}
-                                    </dl>
-                                </div>
-                            {% endif %}
                             {% if item.note %}
                                 <p class="mt-3 text-sm text-gray-500">
                                     <span>{{ trans('common.elements.note') }} : </span>{{ item.note }}

--- a/src/views/pages/customer/orders/single.twig
+++ b/src/views/pages/customer/orders/single.twig
@@ -72,14 +72,14 @@
 {% extends "layouts.customer" %}
 {% block inner_title %}
 <div class="flex justify-between items-center mb-2">
-    <h1 class="font-bold text-lg text-center sm:text-start">
+    <h1 class="font-bold text-lg text-center text-start flex-1">
         {{ page.title }}
         {% if order.source is same as('buy_as_gift') %}
             <span class="inline-block text-primary mx-2"><i class="sicon-gift-sharing"></i>&nbsp;{{ trans('pages.orders.gift_tag') }}</span>
         {% endif %}
     </h1>
     {% if order.links | length %}
-        <div class="flex space-x-2 rtl:space-x-reverse">
+        <div class="flex space-x-2 rtl:space-x-reverse text-start flex-none px-2">
             {% for link in order.links %}
                 <a href="{{link.url}}" class="text-primary" target="_blank">
                     {{ link.label }}


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Enhancement

What is the current behaviour? (You can also link to an open issue here)

* We still use the deprecated way of files & codes

What is the new behaviour? (You can also link to the ticket here)

* No more need to use files & codes, just drop the usage for it, and `order.links` is enough

Does this PR introduce a breaking change?

* No

Screenshots (If appropriate)

* 
![Screenshot 2025-01-01 at 2 38 37 PM](https://github.com/user-attachments/assets/7ff8f1c6-4e4f-417f-8f87-1f4db408a92b)
