### PR TITLE
cast product id to number

### DIFF
--- a/src/assets/js/partials/product-card.js
+++ b/src/assets/js/partials/product-card.js
@@ -166,7 +166,7 @@ class ProductCard extends HTMLElement {
     this.product?.donation?  this.classList.add('s-product-card-donation') : '';
     this.shadowOnHover?  this.classList.add('s-product-card-shadow') : '';
     this.product?.is_out_of_stock?  this.classList.add('s-product-card-out-of-stock') : '';
-    this.isInWishlist = !salla.config.isGuest() && salla.storage.get('salla::wishlist', []).includes(this.product.id);
+    this.isInWishlist = !salla.config.isGuest() && salla.storage.get('salla::wishlist', []).includes(Number(this.product.id));
     this.innerHTML = `
         <div class="${!this.fullImage ? 's-product-card-image' : 's-product-card-image-full'}">
           <a href="${this.product?.url}">


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Bug fix

What is the current behaviour? (You can also link to an open issue here)

*  the product-card.js is not showing red heart when the product is in wishlist 
* because the salla.storage.get('salla::wishlist', []) return array of integer number and the includes(this.product.id) is returning a string causing a mismatch bug the component fail to recognize the id in the array not sure if the error just in my themes . 


What is the new behaviour? (You can also link to the ticket here)

* when the product is in wishlist the heart icon will be red

Does this PR introduce a breaking change?

* 

Screenshots (If appropriate)

* 