### PR TITLE
fix(SP-10763): 🐞 Avoid Casting Cart Item to integer

### DIFF
--- a/src/assets/js/cart.js
+++ b/src/assets/js/cart.js
@@ -60,7 +60,7 @@ class Cart extends BasePage {
       const arrayTwoId = options.map((item) => (item.id));
 
       document.querySelectorAll('.cart-options form')?.forEach((form) => {
-        if (!arrayTwoId.includes(parseInt(form.id.value))) {
+        if (!arrayTwoId.includes(form.id.value)) {
           form.remove();
         }
       })


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Bugfix

What is the current behaviour? (You can also link to an open issue here)

* Because the cartItems ids now are greater than `Number.MAX_SAFE_INTEGER`  we need to use them as strings

What is the new behaviour? (You can also link to the ticket here)

* Cast cartItem as string

Does this PR introduce a breaking change?

* No

Screenshots (If appropriate)

* 