### PR TITLE
fix(catalog): Handle PreOrder Label As Promotion label

### DIFF
--- a/src/assets/js/partials/product-card.js
+++ b/src/assets/js/partials/product-card.js
@@ -57,6 +57,10 @@ class ProductCard extends HTMLElement {
   } 
 
   getProductBadge() {
+    if (this.product?.preorder?.label) {
+      return `<div class="s-product-card-promotion-title">${this.product.preorder.label}</div>`
+    }
+
     if (this.product.promotion_title) {
       return `<div class="s-product-card-promotion-title">${this.product.promotion_title}</div>`
     }


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Bug Fix

What is the current behaviour? (You can also link to an open issue here)

* We only render product badge based on `promotion_title`.

What is the new behaviour? (You can also link to the ticket here)

* we have a new case that products that have preorders labels
<img width="360" height="606" alt="Screenshot 2025-09-14 at 09 54 17" src="https://github.com/user-attachments/assets/f46bb6dd-6dd0-4889-a5d7-735a40e9056f" />


Does this PR introduce a breaking change?

* Nop

Screenshots (If appropriate)

* 