### PR TITLE
feat(themes): update WhatsApp link to use wa.me format

### DIFF
--- a/src/views/pages/thank-you.twig
+++ b/src/views/pages/thank-you.twig
@@ -108,7 +108,7 @@
                     {% if store.contacts.whatsapp %}
                         <div class="text-sm unicode flex items-center">
                             <i class="sicon-whatsapp"></i>
-                            <a href="{{ store.contacts.whatsapp }}" class="hover:text-primary transition"><b
+                            <a href="https://wa.me/{{ store.contacts.whatsapp|replace({' ': '', '+': '', '-': ''}) }}" class="hover:text-primary transition" target="_blank" rel="noopener"><b
                                         class="unicode mx-1.5">{{ store.contacts.whatsapp }}</b></a>
                         </div>
                     {% endif %}


### PR DESCRIPTION
## 🚀 Changes
- 🔗 Updated WhatsApp contact link in thank-you page to use `wa.me` format
- 🔒 Added `target="_blank"` and `rel="noopener"` attributes for security
- 🧹 Implemented phone number sanitization to remove spaces, plus signs, and hyphens

## 📋 What Changed
- 📁 **File Modified**: `src/views/pages/thank-you.twig`
- 📍 **Lines**: 111-112
- ⬅️ **Before**: `<a href="{{ store.contacts.whatsapp }}" ...>`
- ➡️ **After**: `<a href="https://wa.me/{{ store.contacts.whatsapp|replace({' ': '', '+': '', '-': ''}) }}" ...>`

## 🎯 Benefits
- ✅ Direct WhatsApp app opening when clicked
- ✅ Better user experience with native WhatsApp integration
- ✅ Improved security with proper link attributes
- ✅ Clean phone number formatting for wa.me compatibility

## 🧪 Testing
- [x] 📱 WhatsApp link opens correctly in WhatsApp app
- [x] 🔢 Phone number formatting works with various input formats
- [x] 🔗 Link opens in new tab without security issues
- [x] 🚫 No linter errors introduced

## 📱 User Experience
Users can now click the WhatsApp contact link and it will:
1. 📲 Open WhatsApp directly (if installed)
2. 🆕 Open in a new tab for better navigation
3. 🧹 Handle phone numbers with various formatting (spaces, +, -)

## 🔗 Related
- 💬 Improves contact functionality on thank-you page
- 🎯 Enhances customer support accessibility