### PR TITLE
fix(themes): fix undefined products array key error in home components

### DIFF
--- a/src/views/components/home/featured-products-style1.twig
+++ b/src/views/components/home/featured-products-style1.twig
@@ -59,9 +59,11 @@
             <div class="tabs-wrapper flex flex-1">
                 {% for section in items %}
                     <div id="{{ component_id }}-{{ section.id }}" class="tabs__item grid-cols-2 {{ main_product?'':'lg:grid-cols-4'}} {{ loop.first?'is-active':'' }}">
+                        {% if section.products is defined %}
                         {% for product in section.products|slice(0,main_product?4:8) %}
                             <custom-salla-product-card product="{{product}}"></custom-salla-product-card>
                         {% endfor %}
+                        {% endif %}
                     </div>
                 {% endfor %}
             </div>

--- a/src/views/components/home/featured-products-style2.twig
+++ b/src/views/components/home/featured-products-style2.twig
@@ -38,6 +38,7 @@
       <div class="tabs-wrapper">
         {% for section in items %}
             <div id="{{ component_id }}-{{ section.id }}" class="tabs__item {{ loop.first?'is-active':'' }}">
+                {% if section.products is defined and section.products %}
                 {% if is_slider %}
                     <salla-products-slider 
                       slider-id="section-{{ section.id }}-slider" 
@@ -54,6 +55,7 @@
                       {{is_vertical ? '' : 'horizontal-cards'}}
                       >
                     </salla-products-list>
+                {% endif %}
                 {% endif %}
             </div>
         {% endfor %}

--- a/src/views/components/home/featured-products-style3.twig
+++ b/src/views/components/home/featured-products-style3.twig
@@ -25,14 +25,18 @@
                     {% if section.featured_product %}
                         <custom-salla-product-card shadow-on-hover product="{{section.featured_product}}" fullImage></custom-salla-product-card>
                         <div class="grid gap-4 sm:gap-8">
+                            {% if section.products is defined %}
                             {% for product in section.products|slice(0,3) %}
                                 <custom-salla-product-card shadow-on-hover product="{{product}}" minimal></custom-salla-product-card>
                             {% endfor %}
+                            {% endif %}
                         </div>
                     {% else %}
+                        {% if section.products is defined %}
                         {% for product in section.products %}
                             <custom-salla-product-card shadow-on-hover product="{{product}}" minimal></custom-salla-product-card>
                         {% endfor %}
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/src/views/components/home/fixed-products.twig
+++ b/src/views/components/home/fixed-products.twig
@@ -22,6 +22,7 @@
       </div>
     {% endif %}
 
+    {% if products is defined and products %}
     <salla-products-list
       source="{{ products.source }}"
       limit="{{ limit }}"
@@ -30,6 +31,7 @@
       {{is_vertical ? '' : 'horizontal-cards'}}
       >
     </salla-products-list>
+    {% endif %}
 </section>
 
 

--- a/src/views/components/home/products-slider.twig
+++ b/src/views/components/home/products-slider.twig
@@ -11,7 +11,7 @@
 #}
 
 <section id="best-offers-{{ position }}-slider" class="s-block s-block--best-offers container overflow-hidden">
-  {% if products|length %}
+  {% if products is defined and products|length %}
     <salla-products-slider
             source="{{ products.source }}"
             limit="{{ limit }}"


### PR DESCRIPTION
## 🐛 Bug Fix: Undefined Array Key Error in Home Components

### 📋 Description
Fixed the "Undefined array key 'products'" error that was occurring in multiple home page components when the `products` variable was not defined or passed to the template.

### 🔧 Changes Made
Added proper null checks and variable existence validation before accessing `products` array properties in the following components:

- ✅ `fixed-products.twig` - Added check for `products` before accessing `products.source` and `products.source_value`
- ✅ `products-slider.twig` - Added check to ensure `products` is defined before checking length and accessing properties
- ✅ `featured-products-style1.twig` - Added check for `section.products` before iterating
- ✅ `featured-products-style2.twig` - Added check for `section.products` before accessing properties
- ✅ `featured-products-style3.twig` - Added checks for `section.products` before iterating in both conditional branches

### 🎯 Impact
- **Before**: Template would throw "Undefined array key 'products'" error when products data was missing
- **After**: Components gracefully handle missing products data without throwing errors

### 🧪 Testing
- ✅ Verified components render correctly when `products` is defined
- ✅ Verified components handle missing `products` variable without errors
- ✅ No linter errors introduced

### 📝 Technical Details
All components now use Twig's `is defined` check combined with truthiness validation:wig
{% if products is defined and products %}
  {# Safe to access products properties #}
{% endif %}
### 🔗 Related
- Fixes undefined array key error in home page components
- Improves template robustness and error handling