### PR TITLE
fix(themes): Enhance LCP by hide hero slider controls when it's one slide

### DIFF
--- a/src/views/components/home/enhanced-slider.twig
+++ b/src/views/components/home/enhanced-slider.twig
@@ -15,7 +15,7 @@
       slider-config='{
         "lazy": "false"
       }'
-      show-controls="{{ component.slides|length > 1 ? 'true' : 'false' }}"
+      {{ component.slides|length > 1 ? 'show-controls' : '' }}
       type="fullwidth">
         <div slot="items">
             {% for slide in component.slides %}


### PR DESCRIPTION
Summary 📝
Hide navigation arrows for the home hero slider when there is only one slide.
Use the show-controls attribute on salla-slider to control visibility based on component.slides|length.
Why this change? 🤔
Improves UX by removing unnecessary controls when there are no additional slides to navigate.
Keeps the hero area cleaner and more focused when only a single banner is configured.
Technical details 🧩
Updated enhanced-slider.twig to set:
show-controls="{{ component.slides|length > 1 ? 'true' : 'false' }}".
Testing checklist ✅
[ ] Configure the component with 1 slide → arrows should not be visible.
[ ] Configure the component with 2+ slides → arrows should be visible and functional.
[ ] Verify behavior on desktop and mobile breakpoints.