### PR TITLE
fix(themes): remove hero slider controls on single slide to improve LCP

### DIFF
--- a/src/views/components/home/enhanced-slider.twig
+++ b/src/views/components/home/enhanced-slider.twig
@@ -15,7 +15,7 @@
       slider-config='{
         "lazy": "false"
       }'
-      {{ component.slides|length > 1 ? 'show-controls' : '' }}
+      {{ component.slides|length > 1 ? '' : 'show-controls="false"' }}
       type="fullwidth">
         <div slot="items">
             {% for slide in component.slides %}


### PR DESCRIPTION
Summary
✨ Hide hero slider controls when only one slide is present
⚡️ Avoid rendering unused controls to improve LCP and reduce layout shifts
🧹 Keeps markup cleaner for single-slide scenarios
Test Plan
✅ With one slide, verify arrows/controls do not render
✅ With multiple slides, verify arrows/controls still render and work
✅ Check LCP/visual stability on hero section for both cases