### PR TITLE
fix(themes): Fix JS window settings serialization using json_encode

### DIFF
--- a/src/views/layouts/master.twig
+++ b/src/views/layouts/master.twig
@@ -68,11 +68,11 @@
 
 
     <script data-cfasync="false">
-        window.header_is_sticky = "{{theme.settings.get('header_is_sticky', 'Default Value')}}"
-        window.imageZoom = "{{theme.settings.get('imageZoom')}}"
-        window.can_access_wallet = {{ user.can_access_wallet | json_encode }}
-        window.enable_more_menu = "{{ theme.settings.get('enable_more_menu', true) }}"
-        window.enable_add_product_toast = "{{ theme.settings.get('enable_add_product_toast', true) }}"
+        window.header_is_sticky = {{ theme.settings.get('header_is_sticky', 'Default Value') | json_encode | raw }}
+        window.imageZoom = {{ theme.settings.get('imageZoom') | json_encode | raw }}
+        window.can_access_wallet = {{ user.can_access_wallet | json_encode | raw }}
+        window.enable_more_menu = {{ theme.settings.get('enable_more_menu', true) | json_encode | raw }}
+        window.enable_add_product_toast = {{ theme.settings.get('enable_add_product_toast', true) | json_encode | raw }}
     </script>
     
     {% hook 'head:start' %}


### PR DESCRIPTION
**🐛 Fix Array-to-string conversion in theme Twig → JS injection**

**Summary**  
Fixes "Array to string conversion" errors when theme/store settings are passed into JavaScript. Any setting that can be an array (or object) was being output as a string, which caused runtime errors.

**Changes**

- **📄 `master.twig`** (all affected themes)  
  Replaced direct string interpolation of `theme.settings.get(...)` and similar values with **`| json_encode | raw`** so values are safely serialized for JS (strings, booleans, arrays, objects).

**Result**

- ✅ No more Array-to-string conversion from these settings.  
- ✅ JS receives valid JSON (strings, numbers, booleans, arrays, objects).  
- ✅ Same approach used consistently across themes.
