### PR TITLE
feat(ui): Auto-embed YouTube links in page content

### DIFF
--- a/src/views/pages/page-single.twig
+++ b/src/views/pages/page-single.twig
@@ -22,6 +22,39 @@
                 <div class="content-entry">
                     {{ page.content|raw }}
                 </div>
+                <script>
+                    (function () {
+                        var entry = document.currentScript.previousElementSibling;
+                        if (!entry) return;
+                        entry.querySelectorAll('a').forEach(function (a) {
+                            var href = a.getAttribute('href') || '';
+                            var videoId = null;
+
+                            // https://www.youtube.com/embed/VIDEO_ID
+                            var embedMatch = href.match(/youtube\.com\/embed\/([a-zA-Z0-9_-]+)/);
+                            // https://www.youtube.com/watch?v=VIDEO_ID
+                            var watchMatch = href.match(/youtube\.com\/watch\?(?:.*&)?v=([a-zA-Z0-9_-]+)/);
+                            // https://youtu.be/VIDEO_ID
+                            var shortMatch = href.match(/youtu\.be\/([a-zA-Z0-9_-]+)/);
+
+                            if (embedMatch) videoId = embedMatch[1];
+                            else if (watchMatch) videoId = watchMatch[1];
+                            else if (shortMatch) videoId = shortMatch[1];
+
+                            if (!videoId) return;
+
+                            var wrapper = document.createElement('div');
+                            wrapper.style.cssText = 'position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;margin:1rem 0;';
+                            var iframe = document.createElement('iframe');
+                            iframe.src = 'https://www.youtube.com/embed/' + videoId;
+                            iframe.setAttribute('allowfullscreen', '');
+                            iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture');
+                            iframe.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;border:0;';
+                            wrapper.appendChild(iframe);
+                            a.parentNode.replaceChild(wrapper, a);
+                        });
+                    })();
+                </script>
                 <salla-comments item-id="{{page.id}}" type="page"></salla-comments>
             </div>
         </div>


### PR DESCRIPTION
Add an inline script to page-single.twig that scans the rendered page content (the element immediately before the script) for YouTube links and replaces them with responsive iframe embeds. The script extracts video IDs from embed, watch, and youtu.be URLs, wraps iframes in a 16:9 container with styling (border-radius, margin), and sets allow/allowfullscreen attributes for proper playback. This improves UX by automatically converting plain YouTube links into embedded videos without changing the stored page content.

What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* 

What is the current behaviour? (You can also link to an open issue here)

* 

What is the new behaviour? (You can also link to the ticket here)

* 

Does this PR introduce a breaking change?

* 

Screenshots (If appropriate)

* 