### PR TITLE
fix(CP-000): Gate salla-cart-coupons with should_display_available_coupons

### DIFF
--- a/src/views/pages/cart.twig
+++ b/src/views/pages/cart.twig
@@ -233,7 +233,7 @@
                             <b>{{ cart.real_shipping_cost|money }}</b>
                         </div>
 
-                        {% if store.settings.cart.apply_coupon_enabled %}
+                        {% if store.settings.cart.should_display_available_coupons %}
                             <div class="py-5 mb-5">
                                 <salla-cart-coupons></salla-cart-coupons>
                             </div>
@@ -268,7 +268,7 @@
                     </div>
 
                      <!-- Tiered Offer Component -->
-                    <salla-tiered-offer></salla-tiered-offer>
+                    <salla-tiered-offer> </salla-tiered-offer>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Performance fix - Only render coupons component when store has displayable coupons

What is the current behaviour?

* `<salla-cart-coupons>` renders whenever `apply_coupon_enabled` is true, regardless of whether the store has any coupons flagged for checkout display

What is the new behaviour?

* Uses `should_display_available_coupons` setting which is true only when all 3 conditions are met: coupons enabled + apply-on-cart enabled + store has active coupons with `show_checkout_coupon=true`
* Prevents rendering the component entirely when no displayable coupons exist

Does this PR introduce a breaking change?

* No

🤖 Generated with [Claude Code](https://claude.com/claude-code)