### PR TITLE
fix(themes): restore deleted preview images in twilight.json 2

### DIFF
--- a/twilight.json
+++ b/twilight.json
@@ -247,6 +247,7 @@
             },
             "icon": "sicon-image-carousel",
             "path": "home.enhanced-slider",
+            "image": "https://cdn.salla.network/images/themes/raed/preview-images/images-slider-enhancement.png?v=1.1",
             "fields": [
                 {
                     "type": "static",
@@ -347,6 +348,7 @@
             },
             "icon": "sicon-layout-grid-rearrange",
             "path": "home.main-links",
+            "image": "https://cdn.salla.network/images/themes/raed/main-links-with-bg.jpg?v=1.1",
             "fields": [
                 {
                     "type": "static",
@@ -601,6 +603,7 @@
             },
             "icon": "sicon-list-play",
             "path": "home.slider-products-with-header",
+            "image": "https://cdn.salla.network/images/themes/raed/preview-images/slider-products-with-bg.png?v=1.1",
             "fields": [
                 {
                     "type": "static",
@@ -743,6 +746,7 @@
             },
             "icon": "sicon-image",
             "path": "home.enhanced-square-banners",
+            "image": "https://cdn.salla.network/images/themes/raed/preview-images/square-images.png?v=1.1",
             "fields": [
                 {
                     "type": "static",
@@ -918,6 +922,7 @@
             },
             "icon": "sicon-award-ribbon",
             "path": "home.brands",
+            "image": "https://cdn.salla.network/images/themes/raed/preview-images/brands.png?v=1.1",
             "fields": [
                 {
                     "type": "static",
@@ -966,6 +971,7 @@
             },
             "icon": "sicon-chat-bubbles",
             "path": "home.custom-testimonials",
+            "image": "https://cdn.salla.network/images/themes/raed/preview-images/custom-testimonials.png?v=1.1",
             "fields": [
                 {
                     "type": "static",


### PR DESCRIPTION
## 🎯 What’s this PR about?
This PR restores the missing component preview images that were unintentionally removed from `twilight.json`.

## ✅ What was fixed?
- Re-added preview image URLs for:
  - `home.enhanced-slider`
  - `home.main-links`
  - `home.slider-products-with-header`
  - `home.enhanced-square-banners`
  - `home.brands`
  - `home.custom-testimonials`
- Kept the existing component structure unchanged
- Ensured `twilight.json` remains valid JSON

## 🧪 Validation
- Confirmed JSON syntax is valid
- Verified the diff only restores the deleted `image` keys

## 📌 Why this matters
Restoring these preview images improves theme configurability and keeps the visual editing experience clear for merchants in the theme customizer.