### PR TITLE
Fix typo in README about Salla CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Theme Raed will be installed as the default theme when you install Twilight. We'
 ```
 
 ### Theme Preview  
-Usin [Salla CLI](https://github.com/SallaApp/Salla-CLI), the developer can preview the theme as they are being developed.  The `preview` command helps the developer to get a look at the theme in live mode.
+Using [Salla CLI](https://github.com/SallaApp/Salla-CLI), the developer can preview the theme as they are being developed.  The `preview` command helps the developer to get a look at the theme in live mode.
 
 <!-- theme: info -->
 > To run the preview command, the developer must be in the theme's root folder.


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* 

What is the current behaviour? (You can also link to an open issue here)

* 

What is the new behaviour? (You can also link to the ticket here)

* 

Does this PR introduce a breaking change?

* 

Screenshots (If appropriate)

*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a single-word typo in `README.md`, correcting "Usin" to "Using" in the Theme Preview section description of Salla CLI usage. The change is purely cosmetic and has no functional impact.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation-only typo fix with no code or logic changes.

Single-word typo correction in a markdown file; no functional code is touched and no rules are violated.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Corrects typo "Usin" → "Using" in the Theme Preview section; purely cosmetic documentation fix. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #898: Fix typo in README] --> B[README.md]
    B --> C["Line 134: 'Usin' → 'Using'"]
    C --> D[Theme Preview section description corrected]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix typo in README about Salla CLI usage"](https://github.com/sallaapp/theme-raed/commit/36d5eaa47135e4a8e55333743677cfb3fbcf4f87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30655913)</sub>

<!-- /greptile_comment -->