### PR TITLE
feat(TD-13801): add menu skeleton placeholders to header

### DIFF
--- a/src/assets/js/partials/main-menu.js
+++ b/src/assets/js/partials/main-menu.js
@@ -1,5 +1,16 @@
 class NavigationMenu extends HTMLElement {
     connectedCallback() {
+        // Seed a skeleton placeholder shown until the menu data is fetched
+        // and render() replaces this innerHTML with the real menu.
+        this.innerHTML = `
+            <div class="main-menu-skel" aria-hidden="true">
+                <span class="header-skel-item header-skel-item--menu" style="width:80px"></span>
+                <span class="header-skel-item header-skel-item--menu" style="width:60px"></span>
+                <span class="header-skel-item header-skel-item--menu" style="width:90px"></span>
+                <span class="header-skel-item header-skel-item--menu" style="width:70px"></span>
+                <span class="header-skel-item header-skel-item--menu" style="width:80px"></span>
+            </div>`;
+
         salla.onReady()
             .then(() => salla.lang.onLoaded())
             .then(() => {

--- a/src/assets/styles/04-components/header.scss
+++ b/src/assets/styles/04-components/header.scss
@@ -213,3 +213,83 @@ salla-user-menu{
     @apply z-10;
   }
 }
+
+
+/* ============================
+   Menu Skeletons (loading state)
+
+   Only the two menus need a placeholder — they wait on an API request.
+   The other Salla components (search, lang/currency, contacts) render
+   their content synchronously and don't need a skeleton.
+
+   - Top-nav menu : CSS-only via salla-menu[topnav]:not(.hydrated) pseudos
+   - Main menu    : initial innerHTML seeded by NavigationMenu, replaced
+                    when render() runs (`.main-menu-skel` block)
+   ============================ */
+
+@keyframes header-skel-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+%header-skel-shimmer {
+  background-color: rgba(0, 0, 0, 0.06);
+  background-image: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0) 0%,
+    rgba(0, 0, 0, 0.08) 50%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: header-skel-shimmer 1.4s ease-in-out infinite;
+}
+
+// ── Top-nav menu — pure CSS via pseudo-elements ─────────────────
+// Stencil hides every <salla-*> with `visibility:hidden` until the
+// `.hydrated` class is added (which restores visibility: inherit).
+// Override that for our pre-hydration state so the pseudo-element
+// pills are actually visible.
+salla-menu[topnav]:not(.hydrated) {
+  @apply hidden lg:inline-flex items-center gap-2;
+  visibility: visible;
+
+  &::before,
+  &::after {
+    @extend %header-skel-shimmer;
+    content: '';
+    @apply inline-block rounded-full;
+    height: 12px;
+  }
+
+  &::before { width: 60px; }
+  &::after  { width: 50px; }
+}
+
+// ── Main menu — DOM seeded by NavigationMenu ────────────────────
+.main-menu-skel {
+  @apply hidden lg:inline-flex items-center gap-4 mx-6 py-8;
+}
+
+.header-skel-item {
+  @extend %header-skel-shimmer;
+  @apply inline-block rounded-full;
+  height: 14px;
+  width: 80px;
+}
+
+.header-skel-item--menu { height: 14px; width: 80px; }
+
+// ── Dark topnav variant — lift contrast on dark backgrounds ─────
+.topnav-is-dark {
+  .top-navbar salla-menu[topnav]:not(.hydrated)::before,
+  .top-navbar salla-menu[topnav]:not(.hydrated)::after {
+    background-color: rgba(255, 255, 255, 0.08);
+    background-image: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 0.14) 50%,
+      rgba(255, 255, 255, 0) 100%
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Show loading skeletons for the two header menus that wait on an API response, so the header doesn't render with empty gaps while menus are still being fetched. Only the two menus get a skeleton — search, language/currency, and contacts render synchronously and don't need one.

## Changes

**Top-nav menu (`salla-menu[topnav]`) — pure CSS, no DOM injection**
- Skeleton rendered via `salla-menu[topnav]:not(.hydrated)::before` + `::after` (two shimmer pills, 60px and 50px).
- Stencil applies `visibility:hidden` to every `<salla-*>` host until `.hydrated` is added (anti-FOUC). Without an override the pseudo-elements inherit that and stay invisible, so the rule also sets `visibility: visible` on the pre-hydration host. Once Salla adds `.hydrated`, the selector stops matching and the skeleton disappears with no extra JS.

**Main menu (`custom-main-menu`) — initial DOM owned by the component**
- `NavigationMenu.connectedCallback` seeds the element's `innerHTML` with a `.main-menu-skel` block of five shimmer items *before* kicking off `salla.api.component.getMenus()`.
- When `render()` resolves with the menu data it replaces `innerHTML`, cleanly disposing the skeleton.
- Skeleton items align with the eventual `ul.main-menu` (`mx-6`) so there's no horizontal jump when the real menu renders.

**No changes to `header.twig`.** Both skeletons are desktop-only (`hidden lg:inline-flex`) to mirror Salla's existing responsive behavior for the two menus.

## Test plan

- [ ] Cold-load the storefront on desktop — top-nav and main-menu shimmer placeholders are visible until the menus arrive, then swap to real content with no layout jump.
- [ ] Throttle the network (Fast 3G) — skeletons stay visible for the duration of the API call.
- [ ] Resize to mobile (< `lg`) — neither skeleton appears (matches Salla hiding the menus on small screens).
- [ ] Dark topnav (`topnav-is-dark`) — top-nav skeleton pills lift to the lighter contrast variant.
- [ ] Confirm no regression on search bar width, lang/currency button, or contacts row (none of those were touched).