### PR TITLE
fix(ui): custom elements are inline by default; block is required for grid-template-rows fr-unit sizing in Safari

### DIFF
--- a/src/assets/styles/04-components/product.scss
+++ b/src/assets/styles/04-components/product.scss
@@ -223,6 +223,8 @@
 
 // product options file upload component
 .product-option-uploader{
+  display: block; // custom elements are inline by default; block is required for grid-template-rows fr-unit sizing in Safari
+  
   .s-file-upload-wrapper{
     min-height: 120px;
     .filepond--list-scroller{


### PR DESCRIPTION
… grid-template-rows fr-unit sizing in Safari

What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* 

What is the current behaviour? (You can also link to an open issue here)

* 

What is the new behaviour? (You can also link to the ticket here)

* 

Does this PR introduce a breaking change?

* 

Screenshots (If appropriate)

* 