### PR TITLE
fix(themes): use language.code for multilang field resolution

### DIFF
--- a/src/views/components/footer/footer.twig
+++ b/src/views/components/footer/footer.twig
@@ -3,11 +3,11 @@
 		<div class="container grid grid-col-1 lg:grid-cols-6 gap-8 lg:gap-6">
 			<div class="lg:col-span-2 rtl:lg:pl-20 ltr:lg:pr-20">
 				<a href="{{ link('/') }}" class="flex items-center m-0">
-					<h3>{{ (store.name is iterable ? store.name[user.language.code]|default(store.name|first) : store.name) }}</h3>
+					<h3>{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }}</h3>
 				</a>
 				{% if store.description %}
 					<div class="max-w-sm leading-6 mb-6">
-						{{ (store.description is iterable ? store.description[user.language.code]|default(store.description|first) : store.description)|raw  }}
+						{{ (store.description is iterable ? store.description[language.code]|default(store.description|first) : store.description)|raw  }}
           </div>
 				{% endif %}
 

--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -27,7 +27,7 @@
           {% if store.scope %}
               <button class="btn--rounded-gray"
                       onclick="salla.event.dispatch('scopes::open', {'mode': 'default'})">
-                  <i class="sicon-location rtl:ml-1 ltr:mr-1"></i> {{ (store.scope.name is iterable ? store.scope.name[user.language.code]|default(store.scope.name|first) : store.scope.name) }}
+                  <i class="sicon-location rtl:ml-1 ltr:mr-1"></i> {{ (store.scope.name is iterable ? store.scope.name[language.code]|default(store.scope.name|first) : store.scope.name) }}
               </button>
           {% endif %}
 
@@ -51,11 +51,11 @@
                         <i class="sicon-menu text-primary text-2xl"></i>
                       </a>
                       <a class="navbar-brand" href="{{ store.url }}">
-                          <img fetchpriority="high" width="100%" height="100%" loading="eager" src="{{ store.logo|cdn(175) }}" alt="{{ (store.name is iterable ? store.name[user.language.code]|default(store.name|first) : store.name) }} logo">
+                          <img fetchpriority="high" width="100%" height="100%" loading="eager" src="{{ store.logo|cdn(175) }}" alt="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} logo">
                           {% if is_page('index') %}
-                            <h1 class="sr-only">{{ (store.name is iterable ? store.name[user.language.code]|default(store.name|first) : store.name) }}</h1>
+                            <h1 class="sr-only">{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }}</h1>
                           {% else %}
-                            <h2 class="sr-only">{{ (store.name is iterable ? store.name[user.language.code]|default(store.name|first) : store.name) }}</h2>
+                            <h2 class="sr-only">{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }}</h2>
                           {% endif %}
                       </a>
                       <custom-main-menu></custom-main-menu>

--- a/src/views/components/home/brands.twig
+++ b/src/views/components/home/brands.twig
@@ -13,7 +13,7 @@
           <div class="s-block__title">
             {% if component.title %}
               <div class="right-side">
-                <h2>{{ (component.title is iterable ? component.title[user.language.code]|default(component.title|first) : component.title) }}</h2>
+                <h2>{{ (component.title is iterable ? component.title[language.code]|default(component.title|first) : component.title) }}</h2>
                 {# <p>عنوان فرعي توصيفي صغير</p> #}
               </div>
             {% endif %}
@@ -28,12 +28,12 @@
                 {% if loop.first or loop.index0%3==0 %}
                     <a href="{{ brand.url }}"
                        class="brand-item {{ component.brands|length > 5  ? 'sm:row-span-2 sm:h-auto': '' }}">
-                        <img class="max-h-full" width="400" height="300" src="{{ brand.logo }}" alt="{{ (brand.name is iterable ? brand.name[user.language.code]|default(brand.name|first) : brand.name) }}"/>
+                        <img class="max-h-full" width="400" height="300" src="{{ brand.logo }}" alt="{{ (brand.name is iterable ? brand.name[language.code]|default(brand.name|first) : brand.name) }}"/>
                     </a>
                 {% else %}
                     <a href="{{ brand.url }}"
                        class="brand-item">
-                        <img class="max-h-full" width="400" height="300" src="{{ brand.logo }}" alt="{{ (brand.name is iterable ? brand.name[user.language.code]|default(brand.name|first) : brand.name) }}"/>
+                        <img class="max-h-full" width="400" height="300" src="{{ brand.logo }}" alt="{{ (brand.name is iterable ? brand.name[language.code]|default(brand.name|first) : brand.name) }}"/>
                     </a>
                 {% endif %}
             {% endfor %}

--- a/src/views/components/home/custom-testimonials.twig
+++ b/src/views/components/home/custom-testimonials.twig
@@ -10,13 +10,13 @@
 						<div class="s-reviews-testimonial">
 							<div class="s-reviews-testimonial__inner">
 								<div class="s-reviews-testimonial__avatar">
-									<img src="{{ item.avatar }}" loading="lazy" alt="{{ (item.name is iterable ? item.name[user.language.code]|default(item.name|first) : item.name)|trim ? item.name : 'testimonial-' ~ index  }}" class="loaded" width="68" height="68">
+									<img src="{{ item.avatar }}" loading="lazy" alt="{{ (item.name is iterable ? item.name[language.code]|default(item.name|first) : item.name)|trim ? item.name : 'testimonial-' ~ index  }}" class="loaded" width="68" height="68">
 								</div>
 								<div class="s-reviews-testimonial__text">
-									<p class="text-sm leading-6 text-gray-700">{{ (item.text is iterable ? item.text[user.language.code]|default(item.text|first) : item.text) }}</p>
+									<p class="text-sm leading-6 text-gray-700">{{ (item.text is iterable ? item.text[language.code]|default(item.text|first) : item.text) }}</p>
 									<div class="s-reviews-testimonial__name_wrapper items-center">
 										<div class="s-reviews-testimonial__info">
-											<h2 class="font-bold text-sm xs:text-base text-gray-900">{{ (item.name is iterable ? item.name[user.language.code]|default(item.name|first) : item.name) }}</h2>
+											<h2 class="font-bold text-sm xs:text-base text-gray-900">{{ (item.name is iterable ? item.name[language.code]|default(item.name|first) : item.name) }}</h2>
 										</div>
 										<div class="s-reviews-testimonial__rating !mx-0">
 											<salla-rating-stars class="flex" size="small" value="{{ item.stars }}"></salla-rating-stars>

--- a/src/views/components/home/enhanced-slider.twig
+++ b/src/views/components/home/enhanced-slider.twig
@@ -22,8 +22,8 @@
 					<div style="background-image: url({{ slide.image }});" class="{{ slide.without_overlay ? '' : 'overlay-bg' }} bg-cover bg-center absolute inset-0"></div>
                     <div class="flex-center container pb-16 sm:pb-0 home-slider__content relative h-full">
                         <div class=" w-4/6 text-center md:w-7/12 lg:w-5/12 text-white">
-                            <h2 data-swiper-parallax="-500" class="lg:text-title-size font-bold leading-tight mb-4">{{ (slide.title is iterable ? slide.title[user.language.code]|default(slide.title|first) : slide.title) }}</h2>
-                            <p data-swiper-parallax="-300" class="line-clamp-2 description">{{ (slide.description is iterable ? slide.description[user.language.code]|default(slide.description|first) : slide.description) }}</p>
+                            <h2 data-swiper-parallax="-500" class="lg:text-title-size font-bold leading-tight mb-4">{{ (slide.title is iterable ? slide.title[language.code]|default(slide.title|first) : slide.title) }}</h2>
+                            <p data-swiper-parallax="-300" class="line-clamp-2 description">{{ (slide.description is iterable ? slide.description[language.code]|default(slide.description|first) : slide.description) }}</p>
                         </div>
                     </div>
                 </div>

--- a/src/views/components/home/enhanced-square-banners.twig
+++ b/src/views/components/home/enhanced-square-banners.twig
@@ -15,8 +15,8 @@
         {% for index, banner in component.banners %}
             <a  href="{{banner.url}}" aria-label="{{ (banner.title ? banner.title : 'square-banner-' ~ index) | e('html_attr') }}" class="banner-entry lazy {{banner.title ? 'has-overlay' : ''}} {{ component.banners|length <= 3 ? "h-lg-banner" : "h-banner" }}" data-bg="{{ banner.image }}">
                 <article class="banner-entry__text text-with-border">
-                    <h3 class="banner__title font-bold mb-1 leading-6">{{ (banner.title is iterable ? banner.title[user.language.code]|default(banner.title|first) : banner.title) }}</h3>
-                    <p class="banner__description">{{ (banner.description is iterable ? banner.description[user.language.code]|default(banner.description|first) : banner.description) }}</p>
+                    <h3 class="banner__title font-bold mb-1 leading-6">{{ (banner.title is iterable ? banner.title[language.code]|default(banner.title|first) : banner.title) }}</h3>
+                    <p class="banner__description">{{ (banner.description is iterable ? banner.description[language.code]|default(banner.description|first) : banner.description) }}</p>
                 </article>
             </a>
         {% endfor %}

--- a/src/views/components/home/featured-products-style1.twig
+++ b/src/views/components/home/featured-products-style1.twig
@@ -20,7 +20,7 @@
 <section class="s-block s-block-tabs s-block--special-products container" id="{{ component_id }}">
     <div class="s-block__title"> 
       <div class="right-side">
-        <h2>{{ (main_product.title is iterable ? main_product.title[user.language.code]|default(main_product.title|first) : main_product.title) }}</h2>
+        <h2>{{ (main_product.title is iterable ? main_product.title[language.code]|default(main_product.title|first) : main_product.title) }}</h2>
       </div>
       {% if items|length > 1 %}
       <div class="tabs hide-scroll hidden lg:flex">
@@ -29,7 +29,7 @@
                       data-target="{{ component_id }}-{{ section.id }}"
                       data-component-id="{{ component_id }}"
                       class="tab-trigger {{ loop.first?'is-active' : '' }}">
-                  {{ (section.title is iterable ? section.title[user.language.code]|default(section.title|first) : section.title) }}
+                  {{ (section.title is iterable ? section.title[language.code]|default(section.title|first) : section.title) }}
               </salla-button>
           {% endfor %}
       </div>
@@ -50,7 +50,7 @@
                             data-target="{{ component_id }}-{{ section.id }}"
                             data-component-id="{{ component_id }}"
                             class="tab-trigger {{ loop.first?'is-active':'' }}">
-                        {{ (section.title is iterable ? section.title[user.language.code]|default(section.title|first) : section.title) }}
+                        {{ (section.title is iterable ? section.title[language.code]|default(section.title|first) : section.title) }}
                     </salla-button> 
                 {% endfor %}
             </div>

--- a/src/views/components/home/featured-products-style2.twig
+++ b/src/views/components/home/featured-products-style2.twig
@@ -29,7 +29,7 @@
                 data-target="{{ component_id }}-{{ section.id }}"
                 data-component-id="{{ component_id }}"
                 fill="outline">
-                  {{ (section.title is iterable ? section.title[user.language.code]|default(section.title|first) : section.title) }}
+                  {{ (section.title is iterable ? section.title[language.code]|default(section.title|first) : section.title) }}
               </salla-button>
           {% endfor %}
       </div>
@@ -42,14 +42,14 @@
                     <salla-products-slider 
                       slider-id="section-{{ section.id }}-slider" 
                       source="{{ section.products.source }}"
-                      limit="{{ (section.products.limit is iterable ? section.products.limit[user.language.code]|default(section.products.limit|first) : section.products.limit) }}"
+                      limit="{{ (section.products.limit is iterable ? section.products.limit[language.code]|default(section.products.limit|first) : section.products.limit) }}"
                       source-value="{{ section.products.source_value|json_encode }}"
                       >
                     </salla-products-slider>
                 {% else %}
                     <salla-products-list  
                       source="{{ section.products.source }}"
-                      limit="{{ (section.products.limit is iterable ? section.products.limit[user.language.code]|default(section.products.limit|first) : section.products.limit) }}"
+                      limit="{{ (section.products.limit is iterable ? section.products.limit[language.code]|default(section.products.limit|first) : section.products.limit) }}"
                       source-value="{{ section.products.source_value|json_encode }}"
                       {{is_vertical ? '' : 'horizontal-cards'}}
                       >

--- a/src/views/components/home/featured-products-style3.twig
+++ b/src/views/components/home/featured-products-style3.twig
@@ -18,7 +18,7 @@
         {% for section in items %}
             <div>
                 <div class="s-block__title">
-                  <h2>{{ (section.title is iterable ? section.title[user.language.code]|default(section.title|first) : section.title) }}</h2>
+                  <h2>{{ (section.title is iterable ? section.title[language.code]|default(section.title|first) : section.title) }}</h2>
                   {# <p>عنوان فرعي توصيفي صغير</p> #}
                 </div> 
                 <div class="flex-1 grid lg:grid-cols-2 gap-4 sm:gap-8">

--- a/src/views/components/home/main-links.twig
+++ b/src/views/components/home/main-links.twig
@@ -15,7 +15,7 @@
       <salla-slider  
         type="carousel"
         {% if(component.title) or (component.merge_with_top_component) %}
-            block-title="{{ (component.title is iterable ? component.title[user.language.code]|default(component.title|first) : component.title) }}"
+            block-title="{{ (component.title is iterable ? component.title[language.code]|default(component.title|first) : component.title) }}"
         {% endif %}
         controls-outer
         show-controls="{{ component.show_controls ? 'true' : 'false'}}" 
@@ -26,11 +26,11 @@
                     <div class="swiper-slide slide--one-sixth">
                         <a href="{{ cat.url }}" class="slide--cat-entry">
                             {% if cat.image %}
-                              <img src="{{ cat.image ? cat.image : 'images/placeholder.png' | asset }}" class="w-16 h-16 object-cover rounded-full mb-2.5 {{ cat.image ? '' : 'has-placeholder'}}" width="64" height="64" alt="{{ (menu.title is iterable ? menu.title[user.language.code]|default(menu.title|first) : menu.title) }}"/>
+                              <img src="{{ cat.image ? cat.image : 'images/placeholder.png' | asset }}" class="w-16 h-16 object-cover rounded-full mb-2.5 {{ cat.image ? '' : 'has-placeholder'}}" width="64" height="64" alt="{{ (menu.title is iterable ? menu.title[language.code]|default(menu.title|first) : menu.title) }}"/>
                             {% else %}
                               <i class="{{ cat.icon }}"></i>
                             {% endif %}
-                            <h2>{{ (cat.name is iterable ? cat.name[user.language.code]|default(cat.name|first) : cat.name) }}</h2>
+                            <h2>{{ (cat.name is iterable ? cat.name[language.code]|default(cat.name|first) : cat.name) }}</h2>
                         </a>
                     </div>
                 {% endfor %}
@@ -40,7 +40,7 @@
                     <div class="swiper-slide slide--one-sixth">
                         <a href="{{ link.url }}" class="slide--cat-entry">
                             <i class="{{ link.icon }}"></i>
-                            <h2>{{ (link.title is iterable ? link.title[user.language.code]|default(link.title|first) : link.title) }}</h2>
+                            <h2>{{ (link.title is iterable ? link.title[language.code]|default(link.title|first) : link.title) }}</h2>
                         </a>
                     </div>
                   {% endif %}

--- a/src/views/components/home/photos-slider.twig
+++ b/src/views/components/home/photos-slider.twig
@@ -20,7 +20,7 @@
         {% for index, item in items %}
           <div class="swiper-slide">
             <a href="{{item.url}}">
-              <img loading="eager" src="{{ item.image.url }}" class="w-full object-contain rounded-md" height="300" width="1200" alt="{{ (store.name is iterable ? store.name[user.language.code]|default(store.name|first) : store.name) }} image-slider-{{index}}"></img>
+              <img loading="eager" src="{{ item.image.url }}" class="w-full object-contain rounded-md" height="300" width="1200" alt="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} image-slider-{{index}}"></img>
             </a>
           </div>
         {% endfor %}

--- a/src/views/components/home/slider-products-with-header.twig
+++ b/src/views/components/home/slider-products-with-header.twig
@@ -13,10 +13,10 @@
         <div class="container pt-8 sm:pt-20 relative">
             <div>
                 <h3 class="text-lg font-bold leading-12">
-                    {{ (component.title is iterable ? component.title[user.language.code]|default(component.title|first) : component.title) }}
+                    {{ (component.title is iterable ? component.title[language.code]|default(component.title|first) : component.title) }}
                 </h3>
                 <p class="text-sm mb-8 line-clamp-2 max-w-lg">
-                    {{ (component.description is iterable ? component.description[user.language.code]|default(component.description|first) : component.description) }}
+                    {{ (component.description is iterable ? component.description[language.code]|default(component.description|first) : component.description) }}
                 </p>
             </div>
         </div>

--- a/src/views/components/home/square-photos.twig
+++ b/src/views/components/home/square-photos.twig
@@ -26,7 +26,7 @@
                 style="background-size: {{ theme.settings.get('squar_photo_bg_image_size', 'contain') }};"
                 ></div>
                 {% if item.text %}
-                        <h3 class="text-with-border"><span>{{ (item.text is iterable ? item.text[user.language.code]|default(item.text|first) : item.text) }}</span></h3> 
+                        <h3 class="text-with-border"><span>{{ (item.text is iterable ? item.text[language.code]|default(item.text|first) : item.text) }}</span></h3> 
                 {% endif %}
             </a>
         {% endfor %}

--- a/src/views/components/home/store-features.twig
+++ b/src/views/components/home/store-features.twig
@@ -14,8 +14,8 @@
             <div class="feature-icon">
               <i class="{{ item.icon }}"></i>
             </div>
-            <h2>{{ (item.title is iterable ? item.title[user.language.code]|default(item.title|first) : item.title) }}</h2>
-            <p>{{ (item.text is iterable ? item.text[user.language.code]|default(item.text|first) : item.text) }}</p>
+            <h2>{{ (item.title is iterable ? item.title[language.code]|default(item.title|first) : item.title) }}</h2>
+            <p>{{ (item.text is iterable ? item.text[language.code]|default(item.text|first) : item.text) }}</p>
           </div>
       {% endfor %}
     </div>

--- a/src/views/layouts/customer.twig
+++ b/src/views/layouts/customer.twig
@@ -30,7 +30,7 @@
             </nav>
             <div class="main-content w-full flex-1 lg:pt-10 max-w-3xl">
                 {% block inner_title %}
-                    <h1 class="font-bold text-lg text-center sm:rtl:text-right sm:ltr:text-left mb-2">{{ (page.title is iterable ? page.title[user.language.code]|default(page.title|first) : page.title) }}</h1>
+                    <h1 class="font-bold text-lg text-center sm:rtl:text-right sm:ltr:text-left mb-2">{{ (page.title is iterable ? page.title[language.code]|default(page.title|first) : page.title) }}</h1>
                 {% endblock %}
                 {#
                 All customer pages have same header, this layout will wrap the different content.

--- a/src/views/layouts/master.twig
+++ b/src/views/layouts/master.twig
@@ -85,7 +85,7 @@
     
     <style>
         :root {
-            --font-main: '{{ (theme.font.name is iterable ? theme.font.name[user.language.code]|default(theme.font.name|first) : theme.font.name) }}';
+            --font-main: '{{ (theme.font.name is iterable ? theme.font.name[language.code]|default(theme.font.name|first) : theme.font.name) }}';
             --color-primary: {{ theme.color.primary }};
             --color-primary-dark: {{ theme.color.darker(0.15) }};
             --color-primary-light: {{ theme.color.lighter(0.15) }};

--- a/src/views/layouts/master.twig
+++ b/src/views/layouts/master.twig
@@ -129,3 +129,4 @@
 {% block scripts %}{% endblock %}
 </body>
 </html>
+

--- a/src/views/pages/blog/index.twig
+++ b/src/views/pages/blog/index.twig
@@ -43,7 +43,7 @@
                 {% for category in categories %}
                     <li>
                         <a class="p-2.5 block text-sm hover:text-primary {{ category.is_current ? ' is-active' : '' }}" href="{{ category.url }}">
-                            <span class="rtl:ml-auto ltr:mr-auto">{{ (category.name is iterable ? category.name[user.language.code]|default(category.name|first) : category.name) }}</span>
+                            <span class="rtl:ml-auto ltr:mr-auto">{{ (category.name is iterable ? category.name[language.code]|default(category.name|first) : category.name) }}</span>
                         </a>
                     </li>
                   {% endfor %}
@@ -60,7 +60,7 @@
                     {% for category in categories %}
                         <li {{ category.is_current ? ' class="text-primary"' : '' }}>
                             <a class="py-3 block text-sm hover:text-primary" href="{{ category.url }}">
-                                {{ (category.name is iterable ? category.name[user.language.code]|default(category.name|first) : category.name) }}
+                                {{ (category.name is iterable ? category.name[language.code]|default(category.name|first) : category.name) }}
                             </a>
                         </li>
                     {% endfor %}
@@ -94,11 +94,11 @@
                                                         <a href="{{ article.author.url }}"
                                                            class=" flex items-center hover:underline">
                                                             <i class="sicon-user rtl:ml-1 ltr:mr-1"></i>
-                                                            <span class="whitespace-nowrap">{{ (article.author.name is iterable ? article.author.name[user.language.code]|default(article.author.name|first) : article.author.name) }}</span>
+                                                            <span class="whitespace-nowrap">{{ (article.author.name is iterable ? article.author.name[language.code]|default(article.author.name|first) : article.author.name) }}</span>
                                                         </a>
                                                     </div>
                                                     <h3 class="text-sm font-bold leading-normal mb-4">
-                                                        <a href="{{ article.url }}">{{ (article.title is iterable ? article.title[user.language.code]|default(article.title|first) : article.title) }}</a>
+                                                        <a href="{{ article.url }}">{{ (article.title is iterable ? article.title[language.code]|default(article.title|first) : article.title) }}</a>
                                                     </h3>
                                                 </div>
                                                 <p data-swiper-parallax="-300"  class="line-clamp-2 block-slide-anime description">{{ article.summary }}</p>
@@ -111,7 +111,7 @@
                     </salla-slider>
                 {% else %}
                     <div class="sr-only lg:not-sr-only ">
-                        <h1 class="blog-category__title font-bold text-lg mb-8">{{ (page.title is iterable ? page.title[user.language.code]|default(page.title|first) : page.title) }}</h1>
+                        <h1 class="blog-category__title font-bold text-lg mb-8">{{ (page.title is iterable ? page.title[language.code]|default(page.title|first) : page.title) }}</h1>
                     </div>
                 {% endif %}
                 {% if articles|length %}
@@ -135,12 +135,12 @@
                                         </div>
                                         <a href="{{ article.author.url }}" class="flex items-center hover:text-dark">
                                             <i class="sicon-user rtl:ml-1 ltr:mr-1"></i>
-                                            <span class="">{{ (article.author.name is iterable ? article.author.name[user.language.code]|default(article.author.name|first) : article.author.name) }}</span>
+                                            <span class="">{{ (article.author.name is iterable ? article.author.name[language.code]|default(article.author.name|first) : article.author.name) }}</span>
                                         </a>
                                     </div>
 
                                     <h3 class="post-entry__title  text-sm font-bold text-gray-800 leading-6 mb-2.5">
-                                        <a href="{{ article.url }}">{{ (article.title is iterable ? article.title[user.language.code]|default(article.title|first) : article.title) }}</a>
+                                        <a href="{{ article.url }}">{{ (article.title is iterable ? article.title[language.code]|default(article.title|first) : article.title) }}</a>
                                     </h3>
                                     <p class="text-sm text-gray-500 leading-6 mb-2.5">
                                         {{ article.summary }}
@@ -170,7 +170,7 @@
                                             <a href="{{ tag.url }}"
                                                class="py-2 px-4 rounded-large inline-flex items-center text-gray-500 hover:text-dark justify-center text-sm">
                                                 <i class="font-medium sicon-tag rtl:ml-1.5 ltr:mr-1.5"></i>
-                                                <span class="fix-align whitespace-nowrap">{{ (tag.name is iterable ? tag.name[user.language.code]|default(tag.name|first) : tag.name) }}</span>
+                                                <span class="fix-align whitespace-nowrap">{{ (tag.name is iterable ? tag.name[language.code]|default(tag.name|first) : tag.name) }}</span>
                                             </a>
                                         {% endfor %}
                                     </div>

--- a/src/views/pages/blog/single.twig
+++ b/src/views/pages/blog/single.twig
@@ -26,7 +26,7 @@
         </nav>
         <div class="md:flex items-start">
             <div class="main-content blog-category md:w-96 flex-1 bg-white lg:p-8 rounded-md mb-10 md:mb-0">
-                <h1 class="font-bold text-3xl mb-5 leading-10">{{ (article.title is iterable ? article.title[user.language.code]|default(article.title|first) : article.title) }}</h1>
+                <h1 class="font-bold text-3xl mb-5 leading-10">{{ (article.title is iterable ? article.title[language.code]|default(article.title|first) : article.title) }}</h1>
                 <div class="mb-10 text-gray-500 rounded-md inline-flex text-sm rtl:space-x-reverse space-x-5">
                     <div class=" flex items-center">
                         <i class="sicon-calendar-date rtl:ml-1 ltr:mr-1"></i>
@@ -34,7 +34,7 @@
                     </div>
                     <a href="{{ article.author.url }}" class=" flex items-center hover:text-dark">
                         <i class="sicon-user rtl:ml-1 ltr:mr-1"></i>
-                        <span class="">{{ (article.author.name is iterable ? article.author.name[user.language.code]|default(article.author.name|first) : article.author.name) }}</span>
+                        <span class="">{{ (article.author.name is iterable ? article.author.name[language.code]|default(article.author.name|first) : article.author.name) }}</span>
                     </a>
                 </div>
                 {% if article.has_image %}
@@ -64,7 +64,7 @@
                             <a href="{{ tag.url }}"
                                class="py-2 px-4 rounded-large inline-flex items-center text-gray-500 hover:text-dark justify-center text-sm">
                                 <i class="font-medium sicon-tag rtl:ml-1.5 ltr:mr-1.5"></i>
-                                <span class="fix-align whitespace-nowrap">{{ (tag.name is iterable ? tag.name[user.language.code]|default(tag.name|first) : tag.name) }}</span>
+                                <span class="fix-align whitespace-nowrap">{{ (tag.name is iterable ? tag.name[language.code]|default(tag.name|first) : tag.name) }}</span>
                             </a>
                         {% endfor %}
                     </div>
@@ -85,7 +85,7 @@
                             <div class="shrink-0">
                                 <a href="{{ article.url }}"
                                    class="bg-border-color h-24 w-24 rounded-md overflow-hidden flex items-center justify-center">
-                                    <span class="sr-only">{{ (article.name is iterable ? article.name[user.language.code]|default(article.name|first) : article.name) }}</span>
+                                    <span class="sr-only">{{ (article.name is iterable ? article.name[language.code]|default(article.name|first) : article.name) }}</span>
 
                                     {% if article.has_image %}
                                         <img class="h-full w-full object-cover" src="{{ article.image.url }}"
@@ -103,7 +103,7 @@
                                 </div>
 
                                 <h3 class="text-sm font-bold text-gray-800 leading-6">
-                                    <a href="{{ article.url }}" class="hover:underline">{{ (article.title is iterable ? article.title[user.language.code]|default(article.title|first) : article.title) }}</a>
+                                    <a href="{{ article.url }}" class="hover:underline">{{ (article.title is iterable ? article.title[language.code]|default(article.title|first) : article.title) }}</a>
                                 </h3>
                             </div>
                         </div>

--- a/src/views/pages/brands/index.twig
+++ b/src/views/pages/brands/index.twig
@@ -16,7 +16,7 @@
         </nav>
 
         <div class="flex justify-between pt-2 pb-6">
-            <h2 class="font-bold mb-6 md:mb-0">{{ (page.title is iterable ? page.title[user.language.code]|default(page.title|first) : page.title) }}</h2>
+            <h2 class="font-bold mb-6 md:mb-0">{{ (page.title is iterable ? page.title[language.code]|default(page.title|first) : page.title) }}</h2>
         </div>
 
         {% if brands|length %}
@@ -53,7 +53,7 @@
                         <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 grid-flow-row gap-4 md:gap-8">
                             {% for brand in brandGroup %}
                                 <a href="{{ brand.url }}" class="brand-item">
-                                    <img class="max-h-full" width="400" height="300" src="{{ brand.logo }}" alt="{{ (brand.name is iterable ? brand.name[user.language.code]|default(brand.name|first) : brand.name) }}">
+                                    <img class="max-h-full" width="400" height="300" src="{{ brand.logo }}" alt="{{ (brand.name is iterable ? brand.name[language.code]|default(brand.name|first) : brand.name) }}">
                                 </a>
                             {% endfor %}
                         </div>

--- a/src/views/pages/brands/single.twig
+++ b/src/views/pages/brands/single.twig
@@ -18,7 +18,7 @@
   {# Brand banner #} 
   {% if brand.banner %} 
         <div class="brand-page__banner">
-            <img loading="eager" width="1200" height="300" class="w-full max-h-[300px] object-cover rounded-md bg-gray-100" src="{{ brand.banner }}" alt="{{ (brand.name is iterable ? brand.name[user.language.code]|default(brand.name|first) : brand.name) }}"/>
+            <img loading="eager" width="1200" height="300" class="w-full max-h-[300px] object-cover rounded-md bg-gray-100" src="{{ brand.banner }}" alt="{{ (brand.name is iterable ? brand.name[language.code]|default(brand.name|first) : brand.name) }}"/>
         </div>
     {% endif %}
 
@@ -31,10 +31,10 @@
    
         {# brand header #}
         <header class="flex flex-col md:flex-row items-center md:items-start text-center rtl:md:text-right ltr:md:text-left mt-2 mb-12 md:mb-20">
-            <img class="rounded-md w-40 h-24 object-contain shadow-md p-4 bg-white shrink-0" src="{{ brand.logo }}" loading="lazy" alt="{{ (brand.name is iterable ? brand.name[user.language.code]|default(brand.name|first) : brand.name) }}">
+            <img class="rounded-md w-40 h-24 object-contain shadow-md p-4 bg-white shrink-0" src="{{ brand.logo }}" loading="lazy" alt="{{ (brand.name is iterable ? brand.name[language.code]|default(brand.name|first) : brand.name) }}">
             <div class="px-5 pt-3 rtl:text-right">
-                <h1 class="text-2xl font-bold mb-1">{{ (brand.name is iterable ? brand.name[user.language.code]|default(brand.name|first) : brand.name) }}</h1>
-                <h2 class="text-base text-gray-500 font-medium">{{ (brand.description is iterable ? brand.description[user.language.code]|default(brand.description|first) : brand.description)|raw  }}</h2>
+                <h1 class="text-2xl font-bold mb-1">{{ (brand.name is iterable ? brand.name[language.code]|default(brand.name|first) : brand.name) }}</h1>
+                <h2 class="text-base text-gray-500 font-medium">{{ (brand.description is iterable ? brand.description[language.code]|default(brand.description|first) : brand.description)|raw  }}</h2>
             </div>
         </header>
 
@@ -53,7 +53,7 @@
                             </span>
                         <p class="text-sm mb-5 text-center">
                             <span>{{ trans('pages.brands.non_products') }}</span>
-                            {{ (brand.name is iterable ? brand.name[user.language.code]|default(brand.name|first) : brand.name) }}
+                            {{ (brand.name is iterable ? brand.name[language.code]|default(brand.name|first) : brand.name) }}
                         </p>
                     </div>
                 {% endif %}

--- a/src/views/pages/cart.twig
+++ b/src/views/pages/cart.twig
@@ -200,12 +200,12 @@
                     {% if loyalty %}
                         <salla-loyalty-panel
                             prize-points='{{ loyalty.prize.points }}'
-                            prize-title='{{ (loyalty.prize.title is iterable ? loyalty.prize.title[user.language.code]|default(loyalty.prize.title|first) : loyalty.prize.title) }}'>
+                            prize-title='{{ (loyalty.prize.title is iterable ? loyalty.prize.title[language.code]|default(loyalty.prize.title|first) : loyalty.prize.title) }}'>
                         </salla-loyalty-panel>
                     {% endif %}
 
                     <div id="cart-gifting" class="shadow-default bg-white xs:p-2 rounded-md mb-5 relative  {{gift.enabled ? '' : 'hidden' }}">
-                        <salla-gifting id="salla-gifting" class="mt-5" widget-title="{{ trans("pages.cart.gift_widget_title") }}"  widget-subtitle="{{ (gift.text is iterable ? gift.text[user.language.code]|default(gift.text|first) : gift.text) }}" class="mt-5" {{gift.type}}-products  vertical></salla-gifting>
+                        <salla-gifting id="salla-gifting" class="mt-5" widget-title="{{ trans("pages.cart.gift_widget_title") }}"  widget-subtitle="{{ (gift.text is iterable ? gift.text[language.code]|default(gift.text|first) : gift.text) }}" class="mt-5" {{gift.type}}-products  vertical></salla-gifting>
                     </div>
 
                     {% if store.settings.cart.apply_coupon_enabled %}

--- a/src/views/pages/customer/orders/single.twig
+++ b/src/views/pages/customer/orders/single.twig
@@ -74,7 +74,7 @@
 {% block inner_title %}
 <div class="flex justify-between items-center mb-2">
     <h1 class="font-bold text-lg text-center text-start flex-1">
-        {{ (page.title is iterable ? page.title[user.language.code]|default(page.title|first) : page.title) }}
+        {{ (page.title is iterable ? page.title[language.code]|default(page.title|first) : page.title) }}
         {% if order.source is same as('buy_as_gift') %}
             <span class="inline-block text-primary mx-2"><i class="sicon-gift-sharing"></i>&nbsp;{{ trans('pages.orders.gift_tag') }}</span>
         {% endif %}
@@ -106,7 +106,7 @@
                         <span class="text-primary inline-flex items-center rtl:space-x-reverse space-x-1"
                               style="color: {{ order.status.color }}">
                         <i class="mt-1 {{ order.status.icon }}"></i>
-                        <span class=""> {{ (order.status.name is iterable ? order.status.name[user.language.code]|default(order.status.name|first) : order.status.name) }}</span>
+                        <span class=""> {{ (order.status.name is iterable ? order.status.name[language.code]|default(order.status.name|first) : order.status.name) }}</span>
                     </span>
                     {% endif %}
 
@@ -194,15 +194,15 @@
                         <div class="flex items-center space-x-2 rtl:space-x-reverse">
                             {% if package.shipping_company.logo %}
                                 <img src="{{ package.shipping_company.logo }}" class="max-w-16 max-h-8"
-                                     alt="{{ (package.shipping_company.name is iterable ? package.shipping_company.name[user.language.code]|default(package.shipping_company.name|first) : package.shipping_company.name) }}">
+                                     alt="{{ (package.shipping_company.name is iterable ? package.shipping_company.name[language.code]|default(package.shipping_company.name|first) : package.shipping_company.name) }}">
                             {% endif %}
-                            <span>{{ (package.shipping_company.name is iterable ? package.shipping_company.name[user.language.code]|default(package.shipping_company.name|first) : package.shipping_company.name) }}</span>
+                            <span>{{ (package.shipping_company.name is iterable ? package.shipping_company.name[language.code]|default(package.shipping_company.name|first) : package.shipping_company.name) }}</span>
                         </div>
                         <div class="flex space-x-5 rtl:space-x-reverse">
                             {% if package.branch %}
                                 <span>
                                     {{ trans('pages.orders.branch') }}:
-                                    <span class="font-bold">{{ (package.branch.name is iterable ? package.branch.name[user.language.code]|default(package.branch.name|first) : package.branch.name) }}</span>
+                                    <span class="font-bold">{{ (package.branch.name is iterable ? package.branch.name[language.code]|default(package.branch.name|first) : package.branch.name) }}</span>
                                 </span>
                             {% endif %}
                             {% if package.shipping_company.number %}
@@ -214,7 +214,7 @@
                                 <span>{{ trans('pages.orders.status') }}:
                                     <span style="color: {{ package.status.color }}">
                                         <i class="center-v mr-1 {{ package.status.icon }}"></i>
-                                        {{ (package.status.name is iterable ? package.status.name[user.language.code]|default(package.status.name|first) : package.status.name) }}
+                                        {{ (package.status.name is iterable ? package.status.name[language.code]|default(package.status.name|first) : package.status.name) }}
                                     </span>
                                 </span>
                             {% elseif package.shipping_company.tracing_link %}
@@ -238,20 +238,20 @@
                                     <div class="flex rtl:space-x-reverse space-x-5 mb-4">
                                         <a href="{{ item.product.url }}" class="shrink-0">
                                             <img src="{{ item.image ?: 'images/placeholder.png' | asset }}"
-                                                 alt="{{ (item.name is iterable ? item.name[user.language.code]|default(item.name|first) : item.name) }}"
+                                                 alt="{{ (item.name is iterable ? item.name[language.code]|default(item.name|first) : item.name) }}"
                                                  class="w-18 h-14 object-{{ item.image ? 'cover':'contain' }} rounded-md">
                                         </a>
                                         <div>
                                             <a href="{{ item.product.url }}"
                                                class="block leading-5 mb-1.5 md:text-base font-semibold transition-colors text-gray-500 hover:text-primary">
-                                                {{ (item.name is iterable ? item.name[user.language.code]|default(item.name|first) : item.name) }}
+                                                {{ (item.name is iterable ? item.name[language.code]|default(item.name|first) : item.name) }}
                                             </a>
                                             <b>{{ item.price|money }}</b>
                                         </div>
                                     </div>
                                 {% else %}
                                     <div class="w-full  flex  justify-between text-sm py-2.5">
-                                        <span class="w-40 inline-block font-normal">{{ (item.name is iterable ? item.name[user.language.code]|default(item.name|first) : item.name) }}</span>
+                                        <span class="w-40 inline-block font-normal">{{ (item.name is iterable ? item.name[language.code]|default(item.name|first) : item.name) }}</span>
                                         <b>{{ item.price|money }}</b>
                                     </div>
                                 {% endif %}
@@ -326,7 +326,7 @@
                                                                 <a href="{{ attachment.url }}" target="_blank">
                                                                     <img class="h-7 w-7 object-cover rounded-md"
                                                                          src="{{ attachment.url }}"
-                                                                         alt="{{ (item.name is iterable ? item.name[user.language.code]|default(item.name|first) : item.name) }}"/>
+                                                                         alt="{{ (item.name is iterable ? item.name[language.code]|default(item.name|first) : item.name) }}"/>
                                                                 </a>
                                                             </div>
                                                         {% else %}
@@ -436,7 +436,7 @@
                     {% for item in order.options %}
                       {% for option in item.options %}
                         <tr class="border-b last:border-b-0 border-gray-200">
-                          <td class="text-sm p-3">{{ (option.name is iterable ? option.name[user.language.code]|default(option.name|first) : option.name) }} :</td>
+                          <td class="text-sm p-3">{{ (option.name is iterable ? option.name[language.code]|default(option.name|first) : option.name) }} :</td>
                           <td class="text-center p-3 font-medium text-xs">
                           {% if option.reservations %}
                             {% include 'pages.partials.product.reservations' with { reservations: option.reservations } %}

--- a/src/views/pages/landing-page.twig
+++ b/src/views/pages/landing-page.twig
@@ -23,7 +23,7 @@
         <div class="landing-page notfound">
             <header>
                 <div class="header-content container">
-                <a href="{{ store.url }}" class="header-content-logo" aria-label="{{ (store.name is iterable ? store.name[user.language.code]|default(store.name|first) : store.name) }} logo">
+                <a href="{{ store.url }}" class="header-content-logo" aria-label="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} logo">
 					<img src="{{ store.logo }}" width="75" height="75" alt="logo" class="logo"></a>
                     <div class="header-content-inner">
                         <h1> {{trans('common.errors.404')}}</h1>
@@ -40,7 +40,7 @@
         <div class="landing-page expired">
             <header>
                 <div class="header-content container">
-                <a href="{{ store.url }}" aria-label="{{ (store.name is iterable ? store.name[user.language.code]|default(store.name|first) : store.name) }} logo" class="header-content-logo">
+                <a href="{{ store.url }}" aria-label="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} logo" class="header-content-logo">
 					<img src="{{ store.logo }}" width="75" height="75" alt="logo" class="logo"></a>
                     <div class="header-content-inner">
                         <h1> {{trans('pages.offer.offer_finished')}}</h1>
@@ -58,10 +58,10 @@
         <div class="landing-page pb-10">
             <header>
                 <div class="header-content container">
-                <a href="{{ store.url }}" aria-label="{{ (store.name is iterable ? store.name[user.language.code]|default(store.name|first) : store.name) }} logo" class="header-content-logo">
+                <a href="{{ store.url }}" aria-label="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} logo" class="header-content-logo">
 					<img src="{{ store.logo }}" width="75" height="75" alt="logo" class="logo"></a>
                     <div class="header-content-inner">
-                        <h1>{{ (landing.title is iterable ? landing.title[user.language.code]|default(landing.title|first) : landing.title) }}</h1>
+                        <h1>{{ (landing.title is iterable ? landing.title[language.code]|default(landing.title|first) : landing.title) }}</h1>
                         <p>{{ landing.content|raw }}</p>
                     </div>
                     {% if landing.offer_ends_at %}

--- a/src/views/pages/loyalty.twig
+++ b/src/views/pages/loyalty.twig
@@ -48,8 +48,8 @@
                 <i class="sicon-star2 star-anime text-amber-400 text-7xl"></i>
                 <div class="loyalty__banner-content">
                     <div class="info">
-                        <h1>{{ (loyalty.name is iterable ? loyalty.name[user.language.code]|default(loyalty.name|first) : loyalty.name) }}</h1>
-                        <p>{{ (loyalty.description is iterable ? loyalty.description[user.language.code]|default(loyalty.description|first) : loyalty.description) }}</p>
+                        <h1>{{ (loyalty.name is iterable ? loyalty.name[language.code]|default(loyalty.name|first) : loyalty.name) }}</h1>
+                        <p>{{ (loyalty.description is iterable ? loyalty.description[language.code]|default(loyalty.description|first) : loyalty.description) }}</p>
                         {% if user.loyalty_points %}
                             <div class="loyalty-points">
                                 {{ trans('pages.loyalty_program.you_have') }}
@@ -89,7 +89,7 @@
                                     {{ point.points }}
                                     {{ trans("pages.loyalty_program.point") }}
                                 </h3>
-                                <p>{{ (point.description is iterable ? point.description[user.language.code]|default(point.description|first) : point.description) }}</p>
+                                <p>{{ (point.description is iterable ? point.description[language.code]|default(point.description|first) : point.description) }}</p>
                             </div>
                         </div>
 
@@ -121,7 +121,7 @@
                                             width="wide"
                                             href="{{ point.url }}"
                                             class="!rounded-3xl text-sm !py-1.5">
-                                        {{ (point.name is iterable ? point.name[user.language.code]|default(point.name|first) : point.name) }}
+                                        {{ (point.name is iterable ? point.name[language.code]|default(point.name|first) : point.name) }}
                                     </salla-button>
                                 {% endif %}
                             </div>
@@ -137,7 +137,7 @@
               <salla-slider 
                 type="carousel"
                 loop="{{prize_group.items|length < 4  ? 'false' : 'true'}}"
-                block-title="{{ (prize_group.title is iterable ? prize_group.title[user.language.code]|default(prize_group.title|first) : prize_group.title) }}"
+                block-title="{{ (prize_group.title is iterable ? prize_group.title[language.code]|default(prize_group.title|first) : prize_group.title) }}"
                 id="loyalty-slider-{{ prize_group.type }}">
                   <div slot="items">
                       {% for prize in prize_group.items %} 
@@ -147,7 +147,7 @@
                                       <img class="sm:h-full w-full object-cover rounded-t-md"
                                           src="{{ prize.image }}"
                                           loading="lazy"
-                                          alt="{{ (prize.name is iterable ? prize.name[user.language.code]|default(prize.name|first) : prize.name) }}"/>
+                                          alt="{{ (prize.name is iterable ? prize.name[language.code]|default(prize.name|first) : prize.name) }}"/>
                                   {% endset %}
                                   {% if prize.url %}
                                       <a href="{{ prize.url }}" class='product-entry__image h-40'>
@@ -159,12 +159,12 @@
                                   <div class="flex-1 p-5">
                                       <h3 class="product-entry__title leading-6 mb-2.5">
                                           {% if prize.url %}
-                                              <a href="{{ prize.url }}">{{ (prize.name is iterable ? prize.name[user.language.code]|default(prize.name|first) : prize.name) }}</a>
+                                              <a href="{{ prize.url }}">{{ (prize.name is iterable ? prize.name[language.code]|default(prize.name|first) : prize.name) }}</a>
                                           {% else %}
-                                              {{ (prize.name is iterable ? prize.name[user.language.code]|default(prize.name|first) : prize.name) }}
+                                              {{ (prize.name is iterable ? prize.name[language.code]|default(prize.name|first) : prize.name) }}
                                           {% endif %}
                                       </h3>
-                                      <p class="text-sm leading-6 ">{{ (prize.description is iterable ? prize.description[user.language.code]|default(prize.description|first) : prize.description) }}</p>
+                                      <p class="text-sm leading-6 ">{{ (prize.description is iterable ? prize.description[language.code]|default(prize.description|first) : prize.description) }}</p>
                                   </div>
                                   {% if user.type == 'user' %}
                                       <div class="font-bold text-primary p-4 text-center border-t">

--- a/src/views/pages/page-single.twig
+++ b/src/views/pages/page-single.twig
@@ -26,7 +26,7 @@
 
           <div class="flex justify-center">
               <div class="content content--single-page w-full lg:w-10/12 bg-white rounded p-6 lg:p-8 mt-4 lg:mt-12">
-                  <h1 class="font-bold text-2xl mb-6">{{ (page.title is iterable ? page.title[user.language.code]|default(page.title|first) : page.title) }}</h1>
+                  <h1 class="font-bold text-2xl mb-6">{{ (page.title is iterable ? page.title[language.code]|default(page.title|first) : page.title) }}</h1>
                   <div class="content-entry">
                       {{ page.content|raw }}
                   </div>

--- a/src/views/pages/product/index.twig
+++ b/src/views/pages/product/index.twig
@@ -43,7 +43,7 @@
 
 		<div class="main-content flex-1 w-full {{ filters ? 'ltr:lg:ml-8 rtl:lg:mr-8' : '' }}">
 			<div class="mb-4 sm:mb-6 flex justify-between items-center">
-				<h1 class="font-bold text-xl rtl:pl-3 ltr:pr-3" id="page-main-title">{{ (page.title is iterable ? page.title[user.language.code]|default(page.title|first) : page.title)|raw  }}</h1>
+				<h1 class="font-bold text-xl rtl:pl-3 ltr:pr-3" id="page-main-title">{{ (page.title is iterable ? page.title[language.code]|default(page.title|first) : page.title)|raw  }}</h1>
 				<div class="flex items-center space-x-2 rtl:space-x-reverse">
 					{% if filters %}
 						<a href="#filters-menu" class="filters-trigger bg-border-color text-primary lg:hidden mt-2">
@@ -55,7 +55,7 @@
 							<label class="hidden sm:block rtl:ml-3 ltr:mr-3 whitespace-nowrap" for="product-filter">{{ trans('pages.categories.sorting') }}</label>
 							<select id="product-filter" class="form-input pt-0 pb-1 rtl:md:pl-10 ltr:md:pr-10">
 								{% for sort in sort_options %}
-									<option value="{{ sort.id }}" {{ sort.is_selected?'selected':'' }}>{{ (sort.name is iterable ? sort.name[user.language.code]|default(sort.name|first) : sort.name) }}</option>
+									<option value="{{ sort.id }}" {{ sort.is_selected?'selected':'' }}>{{ (sort.name is iterable ? sort.name[language.code]|default(sort.name|first) : sort.name) }}</option>
 								{% endfor %}
 							</select>
 						</div>

--- a/src/views/pages/product/single.twig
+++ b/src/views/pages/product/single.twig
@@ -151,7 +151,7 @@
                                    data-infinite="false"
                                    data-type="{{ image.video_url?'youtube':'image' }}"
                                    href="{{ (image.video_url is iterable ? image.video_url|first : image.video_url)|default(image.url) }}"
-                                   aria-label="{{ (product.name is iterable ? product.name[user.language.code]|default(product.name|first) : product.name) }}"
+                                   aria-label="{{ (product.name is iterable ? product.name[language.code]|default(product.name|first) : product.name) }}"
                                    class="swiper-slide magnify-wrapper homeslider__slide {{ image.video_url?'video-entry':'' }}">
                                     {% if loop.first %}
                                         <img id="{{image.id}}" fetchpriority="high" loading="eager" src="{{ image.url }}"
@@ -197,20 +197,20 @@
 
                 {% if product.brand.name %}
                     <div class="product-brand mb-5 w-12">
-                        <a class="brand-logo" href="{{ product.brand.url }}" title="{{ (product.brand.name is iterable ? product.brand.name[user.language.code]|default(product.brand.name|first) : product.brand.name) }}">
+                        <a class="brand-logo" href="{{ product.brand.url }}" title="{{ (product.brand.name is iterable ? product.brand.name[language.code]|default(product.brand.name|first) : product.brand.name) }}">
                             <img width="100%" height="100%" class="max-h-full object-contain"
                                  src="{{ product.brand.logo }}"
-                                 title="{{ (product.brand.name is iterable ? product.brand.name[user.language.code]|default(product.brand.name|first) : product.brand.name) }}"
-                                 alt="{{ (product.brand.name is iterable ? product.brand.name[user.language.code]|default(product.brand.name|first) : product.brand.name) }}">
+                                 title="{{ (product.brand.name is iterable ? product.brand.name[language.code]|default(product.brand.name|first) : product.brand.name) }}"
+                                 alt="{{ (product.brand.name is iterable ? product.brand.name[language.code]|default(product.brand.name|first) : product.brand.name) }}">
                         </a>
                     </div>
                 {% endif %}
 
-                <h1 class="text-xl md:text-2xl leading-10 font-bold mb-6 text-gray-800">{{ (product.name is iterable ? product.name[user.language.code]|default(product.name|first) : product.name) }}</h1>
+                <h1 class="text-xl md:text-2xl leading-10 font-bold mb-6 text-gray-800">{{ (product.name is iterable ? product.name[language.code]|default(product.name|first) : product.name) }}</h1>
 
                 {% if product.subtitle %}
                     <h2 class="product-entry__sub-title text-sm text-gray-500 leading-6 mb-2.5">
-                        {{ (product.subtitle is iterable ? product.subtitle[user.language.code]|default(product.subtitle|first) : product.subtitle) }}
+                        {{ (product.subtitle is iterable ? product.subtitle[language.code]|default(product.subtitle|first) : product.subtitle) }}
                     </h2>
                 {% endif %}
 
@@ -259,7 +259,7 @@
                     <div class="mb-3">
                         {% for tag in product.tags %}
                             <a href="{{ tag.url }}"
-                               class="rtl:ml-2 ltr:mr-2 inline-flex  text-gray-500 hover:text-primary underline text-sm mb-1">{{ (tag.name is iterable ? tag.name[user.language.code]|default(tag.name|first) : tag.name) }}
+                               class="rtl:ml-2 ltr:mr-2 inline-flex  text-gray-500 hover:text-primary underline text-sm mb-1">{{ (tag.name is iterable ? tag.name[language.code]|default(tag.name|first) : tag.name) }}
                                 ,</a>
                         {% endfor %}
                     </div>

--- a/src/views/pages/testimonials.twig
+++ b/src/views/pages/testimonials.twig
@@ -10,7 +10,7 @@
         <div class="w-full lg:w-10/12 bg-white rounded p-6 lg:p-8 mt-4 lg:mt-12">
 
            <div class="mb-4 sm:mb-6 flex justify-between items-center">
-                <h1 class="font-bold text-2xl">{{ (page.title is iterable ? page.title[user.language.code]|default(page.title|first) : page.title) }}</h1>
+                <h1 class="font-bold text-2xl">{{ (page.title is iterable ? page.title[language.code]|default(page.title|first) : page.title) }}</h1>
                 <div class="flex items-center">
                     <label class="hidden sm:block rtl:ml-3 ltr:mr-3 whitespace-nowrap"
                         for="testimonials-filter">{{ trans('pages.categories.sorting') }}</label>


### PR DESCRIPTION
## 🔍 Problem
PR #983 normalized multilanguage fields using `user.language.code`. That reintroduces a session-dependent `user` property in Twig, which conflicts with STD-13325 (#873) that moved language/dir resolution away from `user` so pages can be fully cached.

## ✅ Changes
- 🛠️ Replace `user.language.code` with `language.code` in all multilang safe-print expressions from #983
- 🎨 Keep the same iterable + `|first` fallback pattern
- 🚫 No `public/` or packaging changes

## 🧪 Testing
- Open homepage components that use multilang titles/texts and confirm they still render without Array-to-string errors
- Switch store language between AR and EN and confirm resolved strings match the selected language
- Confirm html `lang` / RTL behavior from #873 remains intact


Made with [Cursor](https://cursor.com)