### PR TITLE
fix(themes): print store.name directly without language lookup

### DIFF
--- a/src/views/components/footer/footer.twig
+++ b/src/views/components/footer/footer.twig
@@ -3,7 +3,7 @@
 		<div class="container grid grid-col-1 lg:grid-cols-6 gap-8 lg:gap-6">
 			<div class="lg:col-span-2 rtl:lg:pl-20 ltr:lg:pr-20">
 				<a href="{{ link('/') }}" class="flex items-center m-0">
-					<h3>{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }}</h3>
+					<h3>{{ store.name }}</h3>
 				</a>
 				{% if store.description %}
 					<div class="max-w-sm leading-6 mb-6">

--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -51,11 +51,11 @@
                         <i class="sicon-menu text-primary text-2xl"></i>
                       </a>
                       <a class="navbar-brand" href="{{ store.url }}">
-                          <img fetchpriority="high" width="100%" height="100%" loading="eager" src="{{ store.logo|cdn(175) }}" alt="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} logo">
+                          <img fetchpriority="high" width="100%" height="100%" loading="eager" src="{{ store.logo|cdn(175) }}" alt="{{ store.name }} logo">
                           {% if is_page('index') %}
-                            <h1 class="sr-only">{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }}</h1>
+                            <h1 class="sr-only">{{ store.name }}</h1>
                           {% else %}
-                            <h2 class="sr-only">{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }}</h2>
+                            <h2 class="sr-only">{{ store.name }}</h2>
                           {% endif %}
                       </a>
                       <custom-main-menu></custom-main-menu>

--- a/src/views/components/home/photos-slider.twig
+++ b/src/views/components/home/photos-slider.twig
@@ -20,7 +20,7 @@
         {% for index, item in items %}
           <div class="swiper-slide">
             <a href="{{item.url}}">
-              <img loading="eager" src="{{ item.image.url }}" class="w-full object-contain rounded-md" height="300" width="1200" alt="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} image-slider-{{index}}"></img>
+              <img loading="eager" src="{{ item.image.url }}" class="w-full object-contain rounded-md" height="300" width="1200" alt="{{ store.name }} image-slider-{{index}}"></img>
             </a>
           </div>
         {% endfor %}

--- a/src/views/pages/landing-page.twig
+++ b/src/views/pages/landing-page.twig
@@ -23,7 +23,7 @@
         <div class="landing-page notfound">
             <header>
                 <div class="header-content container">
-                <a href="{{ store.url }}" class="header-content-logo" aria-label="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} logo">
+                <a href="{{ store.url }}" class="header-content-logo" aria-label="{{ store.name }} logo">
 					<img src="{{ store.logo }}" width="75" height="75" alt="logo" class="logo"></a>
                     <div class="header-content-inner">
                         <h1> {{trans('common.errors.404')}}</h1>
@@ -40,7 +40,7 @@
         <div class="landing-page expired">
             <header>
                 <div class="header-content container">
-                <a href="{{ store.url }}" aria-label="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} logo" class="header-content-logo">
+                <a href="{{ store.url }}" aria-label="{{ store.name }} logo" class="header-content-logo">
 					<img src="{{ store.logo }}" width="75" height="75" alt="logo" class="logo"></a>
                     <div class="header-content-inner">
                         <h1> {{trans('pages.offer.offer_finished')}}</h1>
@@ -58,7 +58,7 @@
         <div class="landing-page pb-10">
             <header>
                 <div class="header-content container">
-                <a href="{{ store.url }}" aria-label="{{ (store.name is iterable ? store.name[language.code]|default(store.name|first) : store.name) }} logo" class="header-content-logo">
+                <a href="{{ store.url }}" aria-label="{{ store.name }} logo" class="header-content-logo">
 					<img src="{{ store.logo }}" width="75" height="75" alt="logo" class="logo"></a>
                     <div class="header-content-inner">
                         <h1>{{ (landing.title is iterable ? landing.title[language.code]|default(landing.title|first) : landing.title) }}</h1>


### PR DESCRIPTION
## 🔍 Problem
Follow-up to the TD-15050 language.code batch: `store.description` was restored to a direct print, but `store.name` still used the iterable/language lookup ternary. Store name should be rendered the same way — as a platform-resolved scalar, without language conditions.

## ✅ Changes
- 🛠️ Replace `store.name` iterable/`language.code` ternaries with direct `{{ store.name }}`
- 🎨 Keep surrounding markup (aria-label, alt, headings) unchanged
- 🚫 No `public/` or packaging changes

## 🧪 Testing
- Check footer/header logo labels and store name text render correctly
- Switch AR/EN and confirm store name still displays
- Confirm no Array-to-string output for store name
