### PR TITLE
feat(SHPD-9928): Display bullet-delivery-tag on store header

### DIFF
--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -6,7 +6,7 @@
 | cart.total       | string  | Formatted total ex: "١٠٠ ر.س"   |
 #}
 {% set important_links = theme.settings.get('important_links') %}
-<header data-testid="store-header" class="store-header"> 
+<header data-testid="store-header" class="store-header">
   {# Bullet Delivery tag — mobile: own full-width row above the top nav
      (Figma "Mobile version"). Desktop keeps the inline pill below, next to
      scopes. Both instances self-gate on the same backend flag; `lg:hidden`

--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -31,8 +31,8 @@
               </button>
           {% endif %}
 
-          {# Quick Delivery tag — self-gates on store.settings.quick_delivery_eligible #}
-          <salla-quick-delivery-tag></salla-quick-delivery-tag>
+          {# Bullet Delivery tag — self-gates on store.settings.bullet_delivery_eligible #}
+          <salla-bullet-delivery-tag></salla-bullet-delivery-tag>
 
           {# Search bar #}
           <div class="header-search flex-1">

--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -31,10 +31,8 @@
               </button>
           {% endif %}
 
-          {# Quick Delivery tag (homepage only) — self-gates on store.settings.quick_delivery_eligible #}
-          {% if is_page('index') %}
-              <salla-quick-delivery-tag></salla-quick-delivery-tag>
-          {% endif %}
+          {# Quick Delivery tag — self-gates on store.settings.quick_delivery_eligible #}
+          <salla-quick-delivery-tag></salla-quick-delivery-tag>
 
           {# Search bar #}
           <div class="header-search flex-1">

--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -31,6 +31,11 @@
               </button>
           {% endif %}
 
+          {# Quick Delivery tag (homepage only) — self-gates on store.settings.quick_delivery_eligible #}
+          {% if is_page('index') %}
+              <salla-quick-delivery-tag></salla-quick-delivery-tag>
+          {% endif %}
+
           {# Search bar #}
           <div class="header-search flex-1">
             <salla-search data-testid="store-header-search" inline oval height="36"></salla-search>

--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -31,6 +31,11 @@
               {% endif %}
           </div>
 
+          {# Bullet Delivery tag — desktop only; mobile instance is above the top nav #}
+          <div class="hidden lg:block">
+            <salla-bullet-delivery-tag></salla-bullet-delivery-tag>
+          </div>
+
           {# Scopes | Branches #}
           {% if store.scope %}
               <button class="btn--rounded-gray"
@@ -38,11 +43,6 @@
                   <i class="sicon-location rtl:ml-1 ltr:mr-1"></i> {{ store.scope.name }}
               </button>
           {% endif %}
-
-          {# Bullet Delivery tag — desktop only; mobile instance is above the top nav #}
-          <div class="hidden lg:block">
-            <salla-bullet-delivery-tag></salla-bullet-delivery-tag>
-          </div>
 
           {# Search bar #}
           <div class="header-search flex-1">

--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -7,6 +7,14 @@
 #}
 {% set important_links = theme.settings.get('important_links') %}
 <header data-testid="store-header" class="store-header">
+  {# Bullet Delivery tag — mobile: own full-width row above the top nav
+     (Figma "Mobile version"). Desktop keeps the inline pill below, next to
+     scopes. Both instances self-gate on the same backend flag; `lg:hidden`
+     matches the mobile/desktop split already used for the menu toggle below. #}
+  <div class="lg:hidden">
+    <salla-bullet-delivery-tag></salla-bullet-delivery-tag>
+  </div>
+
   {# Top Nav #}
   <div class="top-navbar">
     <div class="container flex justify-between">
@@ -31,8 +39,10 @@
               </button>
           {% endif %}
 
-          {# Bullet Delivery tag — self-gates on store.settings.bullet_delivery_eligible #}
-          <salla-bullet-delivery-tag></salla-bullet-delivery-tag>
+          {# Bullet Delivery tag — desktop only; mobile instance is above the top nav #}
+          <div class="hidden lg:block">
+            <salla-bullet-delivery-tag></salla-bullet-delivery-tag>
+          </div>
 
           {# Search bar #}
           <div class="header-search flex-1">

--- a/src/views/components/header/header.twig
+++ b/src/views/components/header/header.twig
@@ -6,7 +6,7 @@
 | cart.total       | string  | Formatted total ex: "١٠٠ ر.س"   |
 #}
 {% set important_links = theme.settings.get('important_links') %}
-<header data-testid="store-header" class="store-header">
+<header data-testid="store-header" class="store-header"> 
   {# Bullet Delivery tag — mobile: own full-width row above the top nav
      (Figma "Mobile version"). Desktop keeps the inline pill below, next to
      scopes. Both instances self-gate on the same backend flag; `lg:hidden`


### PR DESCRIPTION
## What

Mounts `<salla-quick-delivery-tag>` in the storefront top navbar, beside the delivery-location (scopes) control — the Quick Delivery homepage tag (**توصيل خلال ساعتين** / *Delivery within 2 hours*).

## How

- Placed directly in `header.twig` (the raed header is composed of direct component tags, not hooks — this matches `salla-localization-modal`, `salla-search`, etc.).
- Gated with `{% if is_page('index') %}` — the header is global, and the ticket scopes the tag to the homepage.
- The component (in twilight) self-gates on `store.settings.quick_delivery_eligible`, so it renders only for eligible stores and fails safe to hidden otherwise. Styling ships per-component from twilight (PR #2107) — no `app.css` change.

## Testing

- Verified the component renders as a green pill beside the scopes control on the homepage when the eligibility flag is true.

## Depends on

- SallaApp/twilight#2176 (the `salla-quick-delivery-tag` component)

Jira: https://salla-dev.atlassian.net/browse/SHPD-9928

## screenshot
<img width="1223" height="491" alt="image" src="https://github.com/user-attachments/assets/655ad0c0-8818-4bd8-8880-b698fc78efe8" />
