### PR TITLE
fix(SP-22734): free product ribbon on zero-price items

### DIFF
--- a/src/assets/js/cart.js
+++ b/src/assets/js/cart.js
@@ -149,7 +149,10 @@ class Cart extends BasePage {
             .toggleElementClassIf([regularPriceElement, offerIconElement], 'offer-applied', 'hidden', () => hasSpecialPrice)
             .toggleElementClassIf([itemOriginalPrice], 'offer-applied', 'hidden', () => hasSalePrice)
             .toggleElementClassIf(priceElement, 'text-red-400', 'text-sm text-gray-400', () => hasSpecialPrice)
-            .toggleElementClassIf(freeRibbon, 'active', 'hidden', () => item.price == 0);
+            // Keep this condition in sync with cart.twig — the ribbon marks an item made
+            // free by an offer, not any item that happens to cost 0 (e.g. request-a-quote
+            // products). Dropping `has_discount` here regressed #789 once already.
+            .toggleElementClassIf(freeRibbon, 'active', 'hidden', () => item.price == 0 && item.has_discount);
 
         priceElement.innerHTML = salla.money(item.price);
 


### PR DESCRIPTION
## Summary
- Fix free product ribbon appearing on any zero-price cart item by restoring the `has_discount` check in `updateItemInfo()`, matching the condition already in `cart.twig`.

## Fixed Bugs (from PR commits)
- Free ribbon regression: #789 added `&& item.has_discount` to both `cart.twig` and `cart.js`; #791 ("Improve cart submit button loading") reverted it in `cart.js` only. Since then any product genuinely priced at 0 - e.g. a Service-type request-a-quote product with no offer applied - gets the "منتج مجاني" ribbon as soon as `cart.onUpdated` fires. `cart.twig` kept the correct condition, so the ribbon only appears after a cart interaction re-renders the item.

## Test Plan
- [ ] Product of type "منتج حسب الطلب" priced 0, no offer: add to cart - no free ribbon, before and after changing quantity.
- [ ] Product made free by an active offer: free ribbon still shows after a cart update.
- [ ] Loyalty free-product prize redeemed: free ribbon still shows - `has_discount` is `!empty($offer) || product->isOnSale()`, and it is not yet confirmed that loyalty prizes populate the offers collection. If the ribbon disappears here, the predicate should be `item.offer?.is_free` instead.
- [ ] Setting or clearing `promotion_title` changes nothing about the ribbon either way.
- [ ] Rebuild `public/` bundles before merge - this PR changes source only. The committed bundles still carry the old condition.