### PR TITLE
fix(SP-22787): thank you title duplicated in breadcrumb

### DIFF
--- a/src/assets/styles/04-components/user-pages.scss
+++ b/src/assets/styles/04-components/user-pages.scss
@@ -80,6 +80,24 @@
 /*
 * thank you page
 */
+
+/* The breadcrumb sits on the primary-coloured hero band, so it needs the same
+   treatment `s-breadcrumb-primary-reverse` gives the customer pages. The component
+   only applies that class for `customer.*` slugs, hence the theme-side override. */
+.thankyou-breadcrumbs {
+  a {
+    @apply text-primary-reverse hover:opacity-80;
+  }
+
+  li {
+    @apply text-primary-reverse opacity-80;
+  }
+
+  svg {
+    @apply fill-primary-reverse opacity-70;
+  }
+}
+
 .thankyou-block{
   @apply duration-500 hover:shadow-default flex-1 bg-white p-8 rounded-md mb-6 md:mb-8 flex flex-col items-center justify-center;
 

--- a/src/views/pages/thank-you.twig
+++ b/src/views/pages/thank-you.twig
@@ -20,12 +20,9 @@
         </svg>
     </div>
     <div class="container mb-20">
-        <nav class="w-full py-5">
-            <ol class="list-reset flex items-center text-sm text-primary-reverse">
-                <li><a href="{{ link('/') }}" class="fix-align text-primary-reverse">{{ trans('common.titles.home') }}</a></li>
-                <li><i class="sicon-keyboard_arrow_left mx-2"></i></li>
-                <li><span class="fix-align">{{ trans('common.titles.thank_you') }}</span></li>
-            </ol>
+        {# add breadcumbs container in pages to make a space in case breadcrumbs is off #}
+        <nav class="breadcrumbs thankyou-breadcrumbs w-full py-5">
+            <salla-breadcrumb></salla-breadcrumb>
         </nav>
         <div class="bg-white p-4 md:p-8 rounded-md mb-6 md:mb-8">
             <div class="flex flex-col items-center pt-16 pb-10">

--- a/src/views/pages/thank-you.twig
+++ b/src/views/pages/thank-you.twig
@@ -24,7 +24,7 @@
             <ol class="list-reset flex items-center text-sm text-primary-reverse">
                 <li><a href="{{ link('/') }}" class="fix-align text-primary-reverse">{{ trans('common.titles.home') }}</a></li>
                 <li><i class="sicon-keyboard_arrow_left mx-2"></i></li>
-                <li><span class="fix-align">{{ thank_you_title }}</span></li>
+                <li><span class="fix-align">{{ trans('common.titles.thank_you') }}</span></li>
             </ol>
         </nav>
         <div class="bg-white p-4 md:p-8 rounded-md mb-6 md:mb-8">

--- a/src/views/pages/thank-you.twig
+++ b/src/views/pages/thank-you.twig
@@ -20,7 +20,6 @@
         </svg>
     </div>
     <div class="container mb-20">
-        {# add breadcumbs container in pages to make a space in case breadcrumbs is off #}
         <nav class="breadcrumbs thankyou-breadcrumbs w-full py-5">
             <salla-breadcrumb></salla-breadcrumb>
         </nav>


### PR DESCRIPTION
## Summary
- Fix the order completion message appearing twice on the thank-you page on mobile by using the page title in the breadcrumb instead of the merchant's custom message.

## Fixed Bugs (from PR commits)
- Duplicated completion message: the breadcrumb rendered `thank_you_title`, which is the merchant-editable «رسالة إتمام الطلب» (`order_instruction.thank_title`), not a page label. The default short title fits the coloured hero band on one line, but a long custom message wraps out of the band on mobile and lands on the white background directly above the `<h1>` showing the same text. Desktop is unaffected - the sentence still fits on one line there.

## Test Plan
- [ ] Store with a long custom completion message, mobile viewport: the message appears once, breadcrumb reads «الرئيسية › الإيصال».
- [ ] Same store on desktop: unchanged, no regression.
- [ ] Store with no custom completion message: breadcrumb and heading both still correct.
- [ ] Breadcrumb label matches the browser tab title on both viewports.