### PR TITLE
fix(themes): send the shown sort option when the store default sort is disabled

### DIFF
--- a/src/views/pages/product/index.twig
+++ b/src/views/pages/product/index.twig
@@ -65,8 +65,13 @@
 
 			{% hook 'product:index.items.start' %}
 
+			{# nothing is marked selected when the store default sort is disabled, so fall back to the first enabled option #}
+			{% set selected_sorts = sort_options|filter(sort => sort.is_selected) %}
+			{% set first_sort = sort_options|first %}
+			{% set fallback_sort = (sort_options|length and not selected_sorts|length) ? first_sort.id : '' %}
+
 			<div class="flex">
-				<salla-products-list data-testid="store-products-list" class="flex-1 min-w-0" source="{{ page.slug }}" source-value="{{ page.id }}" {{ filters ?'filters-Results':'' }}></salla-products-list>
+				<salla-products-list data-testid="store-products-list" class="flex-1 min-w-0" source="{{ page.slug }}" source-value="{{ page.id }}" sort-by="{{ fallback_sort }}" {{ filters ?'filters-Results':'' }}></salla-products-list>
 			</div>
 
 			{% hook 'product:index.items.end' %}

--- a/src/views/pages/product/index.twig
+++ b/src/views/pages/product/index.twig
@@ -65,10 +65,9 @@
 
 			{% hook 'product:index.items.start' %}
 
-			{# nothing is marked selected when the store default sort is disabled, so fall back to the first enabled option #}
-			{% set selected_sorts = sort_options|filter(sort => sort.is_selected) %}
+			{# a lone option can never fire the change event, so send it with the first request #}
 			{% set first_sort = sort_options|first %}
-			{% set fallback_sort = (sort_options|length and not selected_sorts|length) ? first_sort.id : '' %}
+			{% set fallback_sort = sort_options|length == 1 ? first_sort.id : '' %}
 
 			<div class="flex">
 				<salla-products-list data-testid="store-products-list" class="flex-1 min-w-0" source="{{ page.slug }}" source-value="{{ page.id }}" sort-by="{{ fallback_sort }}" {{ filters ?'filters-Results':'' }}></salla-products-list>

--- a/src/views/pages/product/index.twig
+++ b/src/views/pages/product/index.twig
@@ -65,9 +65,10 @@
 
 			{% hook 'product:index.items.start' %}
 
-			{# a lone option can never fire the change event, so send it with the first request #}
+			{# nothing is marked selected when the store default sort is disabled, so send the shown option with the first request #}
 			{% set first_sort = sort_options|first %}
-			{% set fallback_sort = sort_options|length == 1 ? first_sort.id : '' %}
+			{% set has_selected_sort = sort_options|filter(sort => sort.is_selected)|length %}
+			{% set fallback_sort = (sort_options|length and not has_selected_sort and first_sort.id != 'ourSuggest') ? first_sort.id : '' %}
 
 			<div class="flex">
 				<salla-products-list data-testid="store-products-list" class="flex-1 min-w-0" source="{{ page.slug }}" source-value="{{ page.id }}" sort-by="{{ fallback_sort }}" {{ filters ?'filters-Results':'' }}></salla-products-list>


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Bug fix

What is the current behaviour? (You can also link to an open issue here)

* The sort option shown in the dropdown never reaches the first products request. `is_selected` is derived only from the `?sort=` query param, so when a merchant disables the store's default sort (`ourSuggest`) no option is marked selected, `salla-products-list` receives no `sort-by`, and the list loads in the API default order while the dropdown shows something else. With a single enabled option the `change` event can never fire, so the mismatch is permanent.

What is the new behaviour? (You can also link to the ticket here)

* When no option is marked selected and the first option is not `ourSuggest`, the page renders `sort-by` from that option so the first request carries the sort the dropdown shows.

| Case | `sort-by` | First request | vs today |
|---|---|---|---|
| First option is `ourSuggest` | `""` | no `sort` param | unchanged |
| `ourSuggest` disabled, 1 option | that option | `&sort=<option>` | fixed |
| `ourSuggest` disabled, 2+ options | first option | `&sort=<first>` | fixed |
| URL has `?sort=` | `""` | `&sort=<from URL>` | unchanged |
| No sort options | `""` | no `sort` param | unchanged |

* Only stores that disabled `ourSuggest` change at all. The `ourSuggest` exclusion is deliberate: the API default is byte-identical to an explicit `sort=ourSuggest`, so emitting it would add a query param to every store's first request for no behavioural gain.
* The "no option selected" condition is what keeps `?sort=` working. After a shopper picks a sort the theme adds `?sort=` via `replaceState`; on reload the backend marks that option selected, the fallback stays empty, and `componentWillLoad` (`this.sortBy || searchParams.get('sort')`) reads the URL instead of being overridden by the attribute.

Does this PR introduce a breaking change?

* No

Screenshots (If appropriate)

*
