### PR TITLE
fix(themes): blank most-sales-products page when sort options are missing

### DIFF
--- a/src/views/pages/product/index.twig
+++ b/src/views/pages/product/index.twig
@@ -66,9 +66,10 @@
 			{% hook 'product:index.items.start' %}
 
 			{# nothing is marked selected when the store default sort is disabled, so send the shown option with the first request #}
-			{% set first_sort = sort_options|first %}
-			{% set has_selected_sort = sort_options|filter(sort => sort.is_selected)|length %}
-			{% set fallback_sort = (sort_options|length and not has_selected_sort and first_sort.id != 'ourSuggest') ? first_sort.id : '' %}
+			{% set sort_list = sort_options|default([]) %}
+			{% set first_sort = sort_list|first %}
+			{% set has_selected_sort = sort_list|filter(sort => sort.is_selected)|length %}
+			{% set fallback_sort = (sort_list|length and not has_selected_sort and first_sort.id != 'ourSuggest') ? first_sort.id : '' %}
 
 			<div class="flex">
 				<salla-products-list data-testid="store-products-list" class="flex-1 min-w-0" source="{{ page.slug }}" source-value="{{ page.id }}" sort-by="{{ fallback_sort }}" {{ filters ?'filters-Results':'' }}></salla-products-list>


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

* Bug fix

What is the current behaviour? (You can also link to an open issue here)

* `/most-Sales-products` renders a blank page (HTTP 200, empty body) on ~647 stores. `ComponentsController::displayMostSalesProducts` hand-builds `['products', 'page_title']` and never passes `sort_options`, unlike the other render sites that go through `HasCategoryPageData::getData()`. `sort_options` is therefore null and `|filter` throws `Twig\Error\RuntimeError: The "filter" filter expects an array or "Traversable", got "NULL"`.

What is the new behaviour? (You can also link to the ticket here)

* `sort_options|default([])` before the filter, so a missing value renders an empty `sort-by` instead of throwing. No change to any case that already worked.

Does this PR introduce a breaking change?

* No

Screenshots (If appropriate)

*
